### PR TITLE
Experimental Terminal support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,19 @@
 All paths in the protocol should be absolute
 
-When updating JSON-RPC methods, their params, or output:
+When I ask you to add a new ACP Agent or Client method:
+
+- Create empty params and output structs in rust/client.rs or rust/agent.rs under the corresponding section. I'll add the fields myself.
+- Do not write any tests or docs at all!
+- Add constants for the method names
+- Add variants to {Agent|Client}{Request|Response} enums
+- Add the methods to the Client/Agent impl of {Agent|Client}SideConnection in rust/acp.rs
+- Handle the new request in the blanket impl of MessageHandler<{Agent|Client}Side>
+- Add the method to markdown_generator.rs SideDocs functions
+- Run `npm run generate` and fix any issues that appear
+- Add the method to typescript/acp.ts classes and handlers
+- Run `npm run check`
+
+When updating existing JSON-RPC methods, their params, or output:
 
 - Update the mintlify docs and guides in the `docs` directory
 - Run `npm run check` to make sure the json and zod schemas gets generated properly

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,19 +1,35 @@
 All paths in the protocol should be absolute
 
-When I ask you to add a new ACP Agent or Client method:
+## Adding new methods
 
 - Create empty params and output structs in rust/client.rs or rust/agent.rs under the corresponding section. I'll add the fields myself.
+- If the protocol method name is `noun/verb`, use `verb_noun` for the user facing methods and structs.
+
+  Example 1 (`noun/noun`):
+  Protocol method: `terminal/output`
+  Trait method name: `terminal_output`
+  Request/Response structs: `TerminalOutputRequest` / `TerminalOutputResponse`
+  Method names struct: `terminal_output: &'static str`
+
+  Example 2 (`noun/verb`):
+  Protocol method: `terminal/new`
+  Trait method name: `new_terminal`
+  Request/Response structs: `NewTerminalRequest` / `NewTerminalResponse`
+  Method names struct: `terminal_new: &'static str`
+
 - Do not write any tests or docs at all!
 - Add constants for the method names
 - Add variants to {Agent|Client}{Request|Response} enums
 - Add the methods to the Client/Agent impl of {Agent|Client}SideConnection in rust/acp.rs
+- Handle the method in the decoders
 - Handle the new request in the blanket impl of MessageHandler<{Agent|Client}Side>
 - Add the method to markdown_generator.rs SideDocs functions
 - Run `npm run generate` and fix any issues that appear
 - Add the method to typescript/acp.ts classes and handlers
 - Run `npm run check`
+- Update the example agents and clients in tests and examples in both libraries
 
-When updating existing JSON-RPC methods, their params, or output:
+## Updating existing methods, their params, or output
 
 - Update the mintlify docs and guides in the `docs` directory
 - Run `npm run check` to make sure the json and zod schemas gets generated properly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ keywords = ["agent", "client", "protocol", "ai", "editor"]
 categories = ["development-tools", "api-bindings"]
 include = ["/rust/**/*.rs", "/README.md", "/LICENSE-APACHE", "/Cargo.toml"]
 
+[features]
+unstable = []
+
 [lib]
 path = "rust/acp.rs"
 doctest = false

--- a/docs/protocol/schema.mdx
+++ b/docs/protocol/schema.mdx
@@ -586,6 +586,22 @@ See protocol docs: [Agent Reports Output](https://agentclientprotocol.com/protoc
 <ResponseField name="truncated" type={"boolean"} required>
 </ResponseField>
 
+<a id="terminal-release"></a>
+### <span class="font-mono">terminal/release</span>
+
+#### <span class="font-mono">ReleaseTerminalRequest</span>
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField
+  name="sessionId"
+  type={<a href="#sessionid">SessionId</a>}
+  required
+></ResponseField>
+<ResponseField name="terminalId" type={"string"} required></ResponseField>
+
 ## <span class="font-mono">AgentCapabilities</span>
 
 Capabilities supported by the agent.

--- a/docs/protocol/schema.mdx
+++ b/docs/protocol/schema.mdx
@@ -517,121 +517,6 @@ See protocol docs: [Agent Reports Output](https://agentclientprotocol.com/protoc
   The actual update content.
 </ResponseField>
 
-<a id="terminal-create"></a>
-### <span class="font-mono">terminal/create</span>
-
-#### <span class="font-mono">CreateTerminalRequest</span>
-
-**Type:** Object
-
-**Properties:**
-
-<ResponseField name="args" type={<><span>"string"</span><span>[]</span></>} >
-</ResponseField>
-<ResponseField name="command" type={"string"} required>
-</ResponseField>
-<ResponseField name="cwd" type={"string | null"} >
-</ResponseField>
-<ResponseField name="env" type={<><span><a href="#envvariable">EnvVariable</a></span><span>[]</span></>} >
-</ResponseField>
-<ResponseField name="outputByteLimit" type={"integer | null"} >
-
-    - Minimum: `0`
-
-</ResponseField>
-<ResponseField name="sessionId" type={<a href="#sessionid">SessionId</a>} required>
-</ResponseField>
-
-#### <span class="font-mono">CreateTerminalResponse</span>
-
-**Type:** Object
-
-**Properties:**
-
-<ResponseField name="terminalId" type={"string"} required></ResponseField>
-
-<a id="terminal-output"></a>
-### <span class="font-mono">terminal/output</span>
-
-#### <span class="font-mono">TerminalOutputRequest</span>
-
-**Type:** Object
-
-**Properties:**
-
-<ResponseField
-  name="sessionId"
-  type={<a href="#sessionid">SessionId</a>}
-  required
-></ResponseField>
-<ResponseField name="terminalId" type={"string"} required></ResponseField>
-
-#### <span class="font-mono">TerminalOutputResponse</span>
-
-**Type:** Object
-
-**Properties:**
-
-<ResponseField
-  name="exitStatus"
-  type={
-    <>
-      <span>
-        <a href="#terminalexitstatus">TerminalExitStatus</a>
-      </span>
-      <span> | null</span>
-    </>
-  }
-></ResponseField>
-<ResponseField name="output" type={"string"} required></ResponseField>
-<ResponseField name="truncated" type={"boolean"} required></ResponseField>
-
-<a id="terminal-release"></a>
-### <span class="font-mono">terminal/release</span>
-
-#### <span class="font-mono">ReleaseTerminalRequest</span>
-
-**Type:** Object
-
-**Properties:**
-
-<ResponseField
-  name="sessionId"
-  type={<a href="#sessionid">SessionId</a>}
-  required
-></ResponseField>
-<ResponseField name="terminalId" type={"string"} required></ResponseField>
-
-<a id="terminal-wait_for_exit"></a>
-### <span class="font-mono">terminal/wait_for_exit</span>
-
-#### <span class="font-mono">WaitForTerminalExitRequest</span>
-
-**Type:** Object
-
-**Properties:**
-
-<ResponseField
-  name="sessionId"
-  type={<a href="#sessionid">SessionId</a>}
-  required
-></ResponseField>
-<ResponseField name="terminalId" type={"string"} required></ResponseField>
-
-#### <span class="font-mono">WaitForTerminalExitResponse</span>
-
-**Type:** Object
-
-**Properties:**
-
-<ResponseField name="exitCode" type={"integer | null"} >
-
-    - Minimum: `0`
-
-</ResponseField>
-<ResponseField name="signal" type={"string | null"} >
-</ResponseField>
-
 ## <span class="font-mono">AgentCapabilities</span>
 
 Capabilities supported by the agent.
@@ -753,6 +638,9 @@ Determines which file operations the agent can request.
 
 </ResponseField>
 <ResponseField name="terminal" type={"boolean"} >
+  **UNSTABLE**
+
+This capability is not part of the spec yet, and may be removed or changed at any point.
 
     - Default: `false`
 
@@ -1613,20 +1501,6 @@ notification, even if the cancellation causes exceptions in underlying operation
 Agents should catch these exceptions and return this semantically meaningful
 response to confirm successful cancellation.
 
-</ResponseField>
-
-## <span class="font-mono">TerminalExitStatus</span>
-
-**Type:** Object
-
-**Properties:**
-
-<ResponseField name="exitCode" type={"integer | null"} >
-
-    - Minimum: `0`
-
-</ResponseField>
-<ResponseField name="signal" type={"string | null"} >
 </ResponseField>
 
 ## <span class="font-mono">TextContent</span>

--- a/docs/protocol/schema.mdx
+++ b/docs/protocol/schema.mdx
@@ -517,10 +517,10 @@ See protocol docs: [Agent Reports Output](https://agentclientprotocol.com/protoc
   The actual update content.
 </ResponseField>
 
-<a id="terminal-new"></a>
-### <span class="font-mono">terminal/new</span>
+<a id="terminal-create"></a>
+### <span class="font-mono">terminal/create</span>
 
-#### <span class="font-mono">NewTerminalRequest</span>
+#### <span class="font-mono">CreateTerminalRequest</span>
 
 **Type:** Object
 
@@ -542,7 +542,7 @@ See protocol docs: [Agent Reports Output](https://agentclientprotocol.com/protoc
 <ResponseField name="sessionId" type={<a href="#sessionid">SessionId</a>} required>
 </ResponseField>
 
-#### <span class="font-mono">NewTerminalResponse</span>
+#### <span class="font-mono">CreateTerminalResponse</span>
 
 **Type:** Object
 

--- a/docs/protocol/schema.mdx
+++ b/docs/protocol/schema.mdx
@@ -70,7 +70,7 @@ See protocol docs: [Initialization](https://agentclientprotocol.com/protocol/ini
 <ResponseField name="clientCapabilities" type={<a href="#clientcapabilities">ClientCapabilities</a>} >
   Capabilities supported by the client.
 
-    - Default: `{"fs":{"readTextFile":false,"writeTextFile":false}}`
+    - Default: `{"fs":{"readTextFile":false,"writeTextFile":false},"terminal":false}`
 
 </ResponseField>
 <ResponseField name="protocolVersion" type={<a href="#protocolversion">ProtocolVersion</a>} required>
@@ -517,6 +517,75 @@ See protocol docs: [Agent Reports Output](https://agentclientprotocol.com/protoc
   The actual update content.
 </ResponseField>
 
+<a id="terminal-new"></a>
+### <span class="font-mono">terminal/new</span>
+
+#### <span class="font-mono">NewTerminalRequest</span>
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="args" type={<><span>"string"</span><span>[]</span></>} >
+</ResponseField>
+<ResponseField name="command" type={"string"} required>
+</ResponseField>
+<ResponseField name="cwd" type={"string | null"} >
+</ResponseField>
+<ResponseField name="env" type={<><span><a href="#envvariable">EnvVariable</a></span><span>[]</span></>} >
+</ResponseField>
+<ResponseField name="outputByteLimit" type={"integer | null"} >
+
+    - Minimum: `0`
+
+</ResponseField>
+<ResponseField name="sessionId" type={<a href="#sessionid">SessionId</a>} required>
+</ResponseField>
+
+#### <span class="font-mono">NewTerminalResponse</span>
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="terminalId" type={"string"} required></ResponseField>
+
+<a id="terminal-output"></a>
+### <span class="font-mono">terminal/output</span>
+
+#### <span class="font-mono">TerminalOutputRequest</span>
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField
+  name="sessionId"
+  type={<a href="#sessionid">SessionId</a>}
+  required
+></ResponseField>
+<ResponseField name="terminalId" type={"string"} required></ResponseField>
+
+#### <span class="font-mono">TerminalOutputResponse</span>
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="exitCode" type={"integer | null"} >
+
+    - Minimum: `0`
+
+</ResponseField>
+<ResponseField name="finished" type={"boolean"} required>
+</ResponseField>
+<ResponseField name="output" type={"string"} required>
+</ResponseField>
+<ResponseField name="signal" type={"string | null"} >
+</ResponseField>
+<ResponseField name="truncated" type={"boolean"} required>
+</ResponseField>
+
 ## <span class="font-mono">AgentCapabilities</span>
 
 Capabilities supported by the agent.
@@ -635,6 +704,11 @@ See protocol docs: [Client Capabilities](https://agentclientprotocol.com/protoco
 Determines which file operations the agent can request.
 
     - Default: `{"readTextFile":false,"writeTextFile":false}`
+
+</ResponseField>
+<ResponseField name="terminal" type={"boolean"} >
+
+    - Default: `false`
 
 </ResponseField>
 
@@ -1637,6 +1711,17 @@ File modification shown as a diff.
 <ResponseField name="path" type={"string"} required>
   The file path being modified.
 </ResponseField>
+<ResponseField name="type" type={"string"} required></ResponseField>
+
+</Expandable>
+</ResponseField>
+
+<ResponseField name="terminal">
+{""}
+
+<Expandable title="Properties">
+
+<ResponseField name="terminalId" type={"string"} required></ResponseField>
 <ResponseField name="type" type={"string"} required></ResponseField>
 
 </Expandable>

--- a/docs/protocol/schema.mdx
+++ b/docs/protocol/schema.mdx
@@ -572,19 +572,19 @@ See protocol docs: [Agent Reports Output](https://agentclientprotocol.com/protoc
 
 **Properties:**
 
-<ResponseField name="exitCode" type={"integer | null"} >
-
-    - Minimum: `0`
-
-</ResponseField>
-<ResponseField name="finished" type={"boolean"} required>
-</ResponseField>
-<ResponseField name="output" type={"string"} required>
-</ResponseField>
-<ResponseField name="signal" type={"string | null"} >
-</ResponseField>
-<ResponseField name="truncated" type={"boolean"} required>
-</ResponseField>
+<ResponseField
+  name="exitStatus"
+  type={
+    <>
+      <span>
+        <a href="#terminalexitstatus">TerminalExitStatus</a>
+      </span>
+      <span> | null</span>
+    </>
+  }
+></ResponseField>
+<ResponseField name="output" type={"string"} required></ResponseField>
+<ResponseField name="truncated" type={"boolean"} required></ResponseField>
 
 <a id="terminal-release"></a>
 ### <span class="font-mono">terminal/release</span>
@@ -601,6 +601,36 @@ See protocol docs: [Agent Reports Output](https://agentclientprotocol.com/protoc
   required
 ></ResponseField>
 <ResponseField name="terminalId" type={"string"} required></ResponseField>
+
+<a id="terminal-wait_for_exit"></a>
+### <span class="font-mono">terminal/wait_for_exit</span>
+
+#### <span class="font-mono">WaitForTerminalExitRequest</span>
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField
+  name="sessionId"
+  type={<a href="#sessionid">SessionId</a>}
+  required
+></ResponseField>
+<ResponseField name="terminalId" type={"string"} required></ResponseField>
+
+#### <span class="font-mono">WaitForTerminalExitResponse</span>
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="exitCode" type={"integer | null"} >
+
+    - Minimum: `0`
+
+</ResponseField>
+<ResponseField name="signal" type={"string | null"} >
+</ResponseField>
 
 ## <span class="font-mono">AgentCapabilities</span>
 
@@ -1583,6 +1613,20 @@ notification, even if the cancellation causes exceptions in underlying operation
 Agents should catch these exceptions and return this semantically meaningful
 response to confirm successful cancellation.
 
+</ResponseField>
+
+## <span class="font-mono">TerminalExitStatus</span>
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="exitCode" type={"integer | null"} >
+
+    - Minimum: `0`
+
+</ResponseField>
+<ResponseField name="signal" type={"string | null"} >
 </ResponseField>
 
 ## <span class="font-mono">TextContent</span>

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "cargo check --all-targets && cargo test && vitest run",
     "test:ts": "vitest run",
     "test:ts:watch": "vitest",
-    "generate:json-schema": "cd rust && cargo run --bin generate",
+    "generate:json-schema": "cd rust && cargo run --bin generate --features unstable",
     "generate:ts-schema": "node typescript/generate.js",
     "generate": "npm run generate:json-schema && npm run generate:ts-schema && npm run format",
     "build": "npm run generate && tsc",

--- a/rust/acp.rs
+++ b/rust/acp.rs
@@ -251,6 +251,9 @@ impl Side for ClientSide {
             TERMINAL_OUTPUT_METHOD_NAME => serde_json::from_str(params.get())
                 .map(AgentRequest::TerminalOutputRequest)
                 .map_err(Into::into),
+            TERMINAL_RELEASE_METHOD_NAME => serde_json::from_str(params.get())
+                .map(AgentRequest::ReleaseTerminalRequest)
+                .map_err(Into::into),
             _ => Err(Error::method_not_found()),
         }
     }
@@ -292,6 +295,10 @@ impl<T: Client> MessageHandler<ClientSide> for T {
             AgentRequest::TerminalOutputRequest(args) => {
                 let response = self.terminal_output(args).await?;
                 Ok(ClientResponse::TerminalOutputResponse(response))
+            }
+            AgentRequest::ReleaseTerminalRequest(args) => {
+                self.release_terminal(args).await?;
+                Ok(ClientResponse::ReleaseTerminalResponse)
             }
         }
     }
@@ -417,6 +424,15 @@ impl Client for AgentSideConnection {
             .request(
                 TERMINAL_OUTPUT_METHOD_NAME,
                 Some(AgentRequest::TerminalOutputRequest(arguments)),
+            )
+            .await
+    }
+
+    async fn release_terminal(&self, arguments: ReleaseTerminalRequest) -> Result<(), Error> {
+        self.conn
+            .request(
+                TERMINAL_RELEASE_METHOD_NAME,
+                Some(AgentRequest::ReleaseTerminalRequest(arguments)),
             )
             .await
     }

--- a/rust/acp.rs
+++ b/rust/acp.rs
@@ -245,8 +245,8 @@ impl Side for ClientSide {
             FS_READ_TEXT_FILE_METHOD_NAME => serde_json::from_str(params.get())
                 .map(AgentRequest::ReadTextFileRequest)
                 .map_err(Into::into),
-            TERMINAL_NEW_METHOD_NAME => serde_json::from_str(params.get())
-                .map(AgentRequest::NewTerminalRequest)
+            TERMINAL_CREATE_METHOD_NAME => serde_json::from_str(params.get())
+                .map(AgentRequest::CreateTerminalRequest)
                 .map_err(Into::into),
             TERMINAL_OUTPUT_METHOD_NAME => serde_json::from_str(params.get())
                 .map(AgentRequest::TerminalOutputRequest)
@@ -291,9 +291,9 @@ impl<T: Client> MessageHandler<ClientSide> for T {
                 let response = self.read_text_file(args).await?;
                 Ok(ClientResponse::ReadTextFileResponse(response))
             }
-            AgentRequest::NewTerminalRequest(args) => {
-                let response = self.new_terminal(args).await?;
-                Ok(ClientResponse::NewTerminalResponse(response))
+            AgentRequest::CreateTerminalRequest(args) => {
+                let response = self.create_terminal(args).await?;
+                Ok(ClientResponse::CreateTerminalResponse(response))
             }
             AgentRequest::TerminalOutputRequest(args) => {
                 let response = self.terminal_output(args).await?;
@@ -411,14 +411,14 @@ impl Client for AgentSideConnection {
             .await
     }
 
-    async fn new_terminal(
+    async fn create_terminal(
         &self,
-        arguments: NewTerminalRequest,
-    ) -> Result<NewTerminalResponse, Error> {
+        arguments: CreateTerminalRequest,
+    ) -> Result<CreateTerminalResponse, Error> {
         self.conn
             .request(
-                TERMINAL_NEW_METHOD_NAME,
-                Some(AgentRequest::NewTerminalRequest(arguments)),
+                TERMINAL_CREATE_METHOD_NAME,
+                Some(AgentRequest::CreateTerminalRequest(arguments)),
             )
             .await
     }

--- a/rust/acp.rs
+++ b/rust/acp.rs
@@ -245,15 +245,19 @@ impl Side for ClientSide {
             FS_READ_TEXT_FILE_METHOD_NAME => serde_json::from_str(params.get())
                 .map(AgentRequest::ReadTextFileRequest)
                 .map_err(Into::into),
+            #[cfg(feature = "unstable")]
             TERMINAL_CREATE_METHOD_NAME => serde_json::from_str(params.get())
                 .map(AgentRequest::CreateTerminalRequest)
                 .map_err(Into::into),
+            #[cfg(feature = "unstable")]
             TERMINAL_OUTPUT_METHOD_NAME => serde_json::from_str(params.get())
                 .map(AgentRequest::TerminalOutputRequest)
                 .map_err(Into::into),
+            #[cfg(feature = "unstable")]
             TERMINAL_RELEASE_METHOD_NAME => serde_json::from_str(params.get())
                 .map(AgentRequest::ReleaseTerminalRequest)
                 .map_err(Into::into),
+            #[cfg(feature = "unstable")]
             TERMINAL_WAIT_FOR_EXIT_METHOD_NAME => serde_json::from_str(params.get())
                 .map(AgentRequest::WaitForTerminalExitRequest)
                 .map_err(Into::into),
@@ -291,18 +295,22 @@ impl<T: Client> MessageHandler<ClientSide> for T {
                 let response = self.read_text_file(args).await?;
                 Ok(ClientResponse::ReadTextFileResponse(response))
             }
+            #[cfg(feature = "unstable")]
             AgentRequest::CreateTerminalRequest(args) => {
                 let response = self.create_terminal(args).await?;
                 Ok(ClientResponse::CreateTerminalResponse(response))
             }
+            #[cfg(feature = "unstable")]
             AgentRequest::TerminalOutputRequest(args) => {
                 let response = self.terminal_output(args).await?;
                 Ok(ClientResponse::TerminalOutputResponse(response))
             }
+            #[cfg(feature = "unstable")]
             AgentRequest::ReleaseTerminalRequest(args) => {
                 self.release_terminal(args).await?;
                 Ok(ClientResponse::ReleaseTerminalResponse)
             }
+            #[cfg(feature = "unstable")]
             AgentRequest::WaitForTerminalExitRequest(args) => {
                 let response = self.wait_for_terminal_exit(args).await?;
                 Ok(ClientResponse::WaitForTerminalExitResponse(response))
@@ -411,6 +419,7 @@ impl Client for AgentSideConnection {
             .await
     }
 
+    #[cfg(feature = "unstable")]
     async fn create_terminal(
         &self,
         arguments: CreateTerminalRequest,
@@ -423,6 +432,7 @@ impl Client for AgentSideConnection {
             .await
     }
 
+    #[cfg(feature = "unstable")]
     async fn terminal_output(
         &self,
         arguments: TerminalOutputRequest,
@@ -435,6 +445,7 @@ impl Client for AgentSideConnection {
             .await
     }
 
+    #[cfg(feature = "unstable")]
     async fn release_terminal(&self, arguments: ReleaseTerminalRequest) -> Result<(), Error> {
         self.conn
             .request(
@@ -444,6 +455,7 @@ impl Client for AgentSideConnection {
             .await
     }
 
+    #[cfg(feature = "unstable")]
     async fn wait_for_terminal_exit(
         &self,
         arguments: WaitForTerminalExitRequest,

--- a/rust/acp.rs
+++ b/rust/acp.rs
@@ -245,6 +245,12 @@ impl Side for ClientSide {
             FS_READ_TEXT_FILE_METHOD_NAME => serde_json::from_str(params.get())
                 .map(AgentRequest::ReadTextFileRequest)
                 .map_err(Into::into),
+            TERMINAL_NEW_METHOD_NAME => serde_json::from_str(params.get())
+                .map(AgentRequest::NewTerminalRequest)
+                .map_err(Into::into),
+            TERMINAL_OUTPUT_METHOD_NAME => serde_json::from_str(params.get())
+                .map(AgentRequest::TerminalOutputRequest)
+                .map_err(Into::into),
             _ => Err(Error::method_not_found()),
         }
     }
@@ -278,6 +284,14 @@ impl<T: Client> MessageHandler<ClientSide> for T {
             AgentRequest::ReadTextFileRequest(args) => {
                 let response = self.read_text_file(args).await?;
                 Ok(ClientResponse::ReadTextFileResponse(response))
+            }
+            AgentRequest::NewTerminalRequest(args) => {
+                let response = self.new_terminal(args).await?;
+                Ok(ClientResponse::NewTerminalResponse(response))
+            }
+            AgentRequest::TerminalOutputRequest(args) => {
+                let response = self.terminal_output(args).await?;
+                Ok(ClientResponse::TerminalOutputResponse(response))
             }
         }
     }
@@ -379,6 +393,30 @@ impl Client for AgentSideConnection {
             .request(
                 FS_READ_TEXT_FILE_METHOD_NAME,
                 Some(AgentRequest::ReadTextFileRequest(arguments)),
+            )
+            .await
+    }
+
+    async fn new_terminal(
+        &self,
+        arguments: NewTerminalRequest,
+    ) -> Result<NewTerminalResponse, Error> {
+        self.conn
+            .request(
+                TERMINAL_NEW_METHOD_NAME,
+                Some(AgentRequest::NewTerminalRequest(arguments)),
+            )
+            .await
+    }
+
+    async fn terminal_output(
+        &self,
+        arguments: TerminalOutputRequest,
+    ) -> Result<TerminalOutputResponse, Error> {
+        self.conn
+            .request(
+                TERMINAL_OUTPUT_METHOD_NAME,
+                Some(AgentRequest::TerminalOutputRequest(arguments)),
             )
             .await
     }

--- a/rust/client.rs
+++ b/rust/client.rs
@@ -54,10 +54,10 @@ pub trait Client {
         args: ReadTextFileRequest,
     ) -> impl Future<Output = Result<ReadTextFileResponse, Error>>;
 
-    fn new_terminal(
+    fn create_terminal(
         &self,
-        args: NewTerminalRequest,
-    ) -> impl Future<Output = Result<NewTerminalResponse, Error>>;
+        args: CreateTerminalRequest,
+    ) -> impl Future<Output = Result<CreateTerminalResponse, Error>>;
 
     fn terminal_output(
         &self,
@@ -277,9 +277,9 @@ impl std::fmt::Display for TerminalId {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[schemars(extend("x-side" = "client", "x-method" = "terminal/new"))]
+#[schemars(extend("x-side" = "client", "x-method" = "terminal/create"))]
 #[serde(rename_all = "camelCase")]
-pub struct NewTerminalRequest {
+pub struct CreateTerminalRequest {
     pub session_id: SessionId,
     pub command: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -293,9 +293,9 @@ pub struct NewTerminalRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[schemars(extend("x-side" = "client", "x-method" = "terminal/new"))]
+#[schemars(extend("x-side" = "client", "x-method" = "terminal/create"))]
 #[serde(rename_all = "camelCase")]
-pub struct NewTerminalResponse {
+pub struct CreateTerminalResponse {
     pub terminal_id: TerminalId,
 }
 
@@ -396,7 +396,7 @@ pub struct ClientMethodNames {
     /// Method for reading text files.
     pub fs_read_text_file: &'static str,
     /// Method for creating new terminals.
-    pub terminal_new: &'static str,
+    pub terminal_create: &'static str,
     /// Method for getting terminals output.
     pub terminal_output: &'static str,
     /// Method for releasing a terminal.
@@ -411,7 +411,7 @@ pub const CLIENT_METHOD_NAMES: ClientMethodNames = ClientMethodNames {
     session_request_permission: SESSION_REQUEST_PERMISSION_METHOD_NAME,
     fs_write_text_file: FS_WRITE_TEXT_FILE_METHOD_NAME,
     fs_read_text_file: FS_READ_TEXT_FILE_METHOD_NAME,
-    terminal_new: TERMINAL_NEW_METHOD_NAME,
+    terminal_create: TERMINAL_CREATE_METHOD_NAME,
     terminal_output: TERMINAL_OUTPUT_METHOD_NAME,
     terminal_release: TERMINAL_RELEASE_METHOD_NAME,
     terminal_wait_for_exit: TERMINAL_WAIT_FOR_EXIT_METHOD_NAME,
@@ -426,7 +426,7 @@ pub(crate) const FS_WRITE_TEXT_FILE_METHOD_NAME: &str = "fs/write_text_file";
 /// Method name for reading text files.
 pub(crate) const FS_READ_TEXT_FILE_METHOD_NAME: &str = "fs/read_text_file";
 /// Method name for creating a new terminal.
-pub(crate) const TERMINAL_NEW_METHOD_NAME: &str = "terminal/new";
+pub(crate) const TERMINAL_CREATE_METHOD_NAME: &str = "terminal/create";
 /// Method for getting terminals output.
 pub(crate) const TERMINAL_OUTPUT_METHOD_NAME: &str = "terminal/output";
 /// Method for releasing a terminal.
@@ -447,7 +447,7 @@ pub enum AgentRequest {
     WriteTextFileRequest(WriteTextFileRequest),
     ReadTextFileRequest(ReadTextFileRequest),
     RequestPermissionRequest(RequestPermissionRequest),
-    NewTerminalRequest(NewTerminalRequest),
+    CreateTerminalRequest(CreateTerminalRequest),
     TerminalOutputRequest(TerminalOutputRequest),
     ReleaseTerminalRequest(ReleaseTerminalRequest),
     WaitForTerminalExitRequest(WaitForTerminalExitRequest),
@@ -466,7 +466,7 @@ pub enum ClientResponse {
     WriteTextFileResponse,
     ReadTextFileResponse(ReadTextFileResponse),
     RequestPermissionResponse(RequestPermissionResponse),
-    NewTerminalResponse(NewTerminalResponse),
+    CreateTerminalResponse(CreateTerminalResponse),
     TerminalOutputResponse(TerminalOutputResponse),
     ReleaseTerminalResponse,
     WaitForTerminalExitResponse(WaitForTerminalExitResponse),

--- a/rust/client.rs
+++ b/rust/client.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{ContentBlock, EnvVariable, Error, Plan, SessionId, ToolCall, ToolCallUpdate};
+use crate::{ContentBlock, Error, Plan, SessionId, ToolCall, ToolCallUpdate};
 
 /// Defines the interface that ACP-compliant clients must implement.
 ///
@@ -76,6 +76,7 @@ pub trait Client {
     ///
     /// This method is not part of the spec, and may be removed or changed at any point.
     #[doc(hidden)]
+    #[cfg(feature = "unstable")]
     fn create_terminal(
         &self,
         args: CreateTerminalRequest,
@@ -85,6 +86,7 @@ pub trait Client {
     ///
     /// This method is not part of the spec, and may be removed or changed at any point.
     #[doc(hidden)]
+    #[cfg(feature = "unstable")]
     fn terminal_output(
         &self,
         args: TerminalOutputRequest,
@@ -94,6 +96,7 @@ pub trait Client {
     ///
     /// This method is not part of the spec, and may be removed or changed at any point.
     #[doc(hidden)]
+    #[cfg(feature = "unstable")]
     fn release_terminal(
         &self,
         args: ReleaseTerminalRequest,
@@ -103,6 +106,7 @@ pub trait Client {
     ///
     /// This method is not part of the spec, and may be removed or changed at any point.
     #[doc(hidden)]
+    #[cfg(feature = "unstable")]
     fn wait_for_terminal_exit(
         &self,
         args: WaitForTerminalExitRequest,
@@ -286,8 +290,10 @@ pub struct ReadTextFileResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash)]
 #[serde(transparent)]
+#[cfg(feature = "unstable")]
 pub struct TerminalId(pub Arc<str>);
 
+#[cfg(feature = "unstable")]
 impl std::fmt::Display for TerminalId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
@@ -297,13 +303,14 @@ impl std::fmt::Display for TerminalId {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[schemars(extend("x-docs-ignore" = true))]
 #[serde(rename_all = "camelCase")]
+#[cfg(feature = "unstable")]
 pub struct CreateTerminalRequest {
     pub session_id: SessionId,
     pub command: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub args: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub env: Vec<EnvVariable>,
+    pub env: Vec<crate::EnvVariable>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cwd: Option<PathBuf>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -313,6 +320,7 @@ pub struct CreateTerminalRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[schemars(extend("x-docs-ignore" = true))]
 #[serde(rename_all = "camelCase")]
+#[cfg(feature = "unstable")]
 pub struct CreateTerminalResponse {
     pub terminal_id: TerminalId,
 }
@@ -320,6 +328,7 @@ pub struct CreateTerminalResponse {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[schemars(extend("x-docs-ignore" = true))]
 #[serde(rename_all = "camelCase")]
+#[cfg(feature = "unstable")]
 pub struct TerminalOutputRequest {
     pub session_id: SessionId,
     pub terminal_id: TerminalId,
@@ -328,6 +337,7 @@ pub struct TerminalOutputRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[schemars(extend("x-docs-ignore" = true))]
 #[serde(rename_all = "camelCase")]
+#[cfg(feature = "unstable")]
 pub struct TerminalOutputResponse {
     pub output: String,
     pub truncated: bool,
@@ -337,6 +347,7 @@ pub struct TerminalOutputResponse {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[schemars(extend("x-docs-ignore" = true))]
 #[serde(rename_all = "camelCase")]
+#[cfg(feature = "unstable")]
 pub struct ReleaseTerminalRequest {
     pub session_id: SessionId,
     pub terminal_id: TerminalId,
@@ -345,6 +356,7 @@ pub struct ReleaseTerminalRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[schemars(extend("x-docs-ignore" = true))]
 #[serde(rename_all = "camelCase")]
+#[cfg(feature = "unstable")]
 pub struct WaitForTerminalExitRequest {
     pub session_id: SessionId,
     pub terminal_id: TerminalId,
@@ -353,6 +365,7 @@ pub struct WaitForTerminalExitRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[schemars(extend("x-docs-ignore" = true))]
 #[serde(rename_all = "camelCase")]
+#[cfg(feature = "unstable")]
 pub struct WaitForTerminalExitResponse {
     #[serde(flatten)]
     pub exit_status: TerminalExitStatus,
@@ -361,6 +374,7 @@ pub struct WaitForTerminalExitResponse {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[schemars(extend("x-docs-ignore" = true))]
 #[serde(rename_all = "camelCase")]
+#[cfg(feature = "unstable")]
 pub struct TerminalExitStatus {
     pub exit_code: Option<u32>,
     pub signal: Option<String>,
@@ -420,12 +434,16 @@ pub struct ClientMethodNames {
     /// Method for reading text files.
     pub fs_read_text_file: &'static str,
     /// Method for creating new terminals.
+    #[cfg(feature = "unstable")]
     pub terminal_create: &'static str,
     /// Method for getting terminals output.
+    #[cfg(feature = "unstable")]
     pub terminal_output: &'static str,
     /// Method for releasing a terminal.
+    #[cfg(feature = "unstable")]
     pub terminal_release: &'static str,
     /// Method for waiting for a terminal to finish.
+    #[cfg(feature = "unstable")]
     pub terminal_wait_for_exit: &'static str,
 }
 
@@ -435,9 +453,13 @@ pub const CLIENT_METHOD_NAMES: ClientMethodNames = ClientMethodNames {
     session_request_permission: SESSION_REQUEST_PERMISSION_METHOD_NAME,
     fs_write_text_file: FS_WRITE_TEXT_FILE_METHOD_NAME,
     fs_read_text_file: FS_READ_TEXT_FILE_METHOD_NAME,
+    #[cfg(feature = "unstable")]
     terminal_create: TERMINAL_CREATE_METHOD_NAME,
+    #[cfg(feature = "unstable")]
     terminal_output: TERMINAL_OUTPUT_METHOD_NAME,
+    #[cfg(feature = "unstable")]
     terminal_release: TERMINAL_RELEASE_METHOD_NAME,
+    #[cfg(feature = "unstable")]
     terminal_wait_for_exit: TERMINAL_WAIT_FOR_EXIT_METHOD_NAME,
 };
 
@@ -450,12 +472,16 @@ pub(crate) const FS_WRITE_TEXT_FILE_METHOD_NAME: &str = "fs/write_text_file";
 /// Method name for reading text files.
 pub(crate) const FS_READ_TEXT_FILE_METHOD_NAME: &str = "fs/read_text_file";
 /// Method name for creating a new terminal.
+#[cfg(feature = "unstable")]
 pub(crate) const TERMINAL_CREATE_METHOD_NAME: &str = "terminal/create";
 /// Method for getting terminals output.
+#[cfg(feature = "unstable")]
 pub(crate) const TERMINAL_OUTPUT_METHOD_NAME: &str = "terminal/output";
 /// Method for releasing a terminal.
+#[cfg(feature = "unstable")]
 pub(crate) const TERMINAL_RELEASE_METHOD_NAME: &str = "terminal/release";
 /// Method for waiting for a terminal to finish.
+#[cfg(feature = "unstable")]
 pub(crate) const TERMINAL_WAIT_FOR_EXIT_METHOD_NAME: &str = "terminal/wait_for_exit";
 
 /// All possible requests that an agent can send to a client.
@@ -471,9 +497,13 @@ pub enum AgentRequest {
     WriteTextFileRequest(WriteTextFileRequest),
     ReadTextFileRequest(ReadTextFileRequest),
     RequestPermissionRequest(RequestPermissionRequest),
+    #[cfg(feature = "unstable")]
     CreateTerminalRequest(CreateTerminalRequest),
+    #[cfg(feature = "unstable")]
     TerminalOutputRequest(TerminalOutputRequest),
+    #[cfg(feature = "unstable")]
     ReleaseTerminalRequest(ReleaseTerminalRequest),
+    #[cfg(feature = "unstable")]
     WaitForTerminalExitRequest(WaitForTerminalExitRequest),
 }
 
@@ -490,9 +520,13 @@ pub enum ClientResponse {
     WriteTextFileResponse,
     ReadTextFileResponse(ReadTextFileResponse),
     RequestPermissionResponse(RequestPermissionResponse),
+    #[cfg(feature = "unstable")]
     CreateTerminalResponse(CreateTerminalResponse),
+    #[cfg(feature = "unstable")]
     TerminalOutputResponse(TerminalOutputResponse),
+    #[cfg(feature = "unstable")]
     ReleaseTerminalResponse,
+    #[cfg(feature = "unstable")]
     WaitForTerminalExitResponse(WaitForTerminalExitResponse),
 }
 

--- a/rust/client.rs
+++ b/rust/client.rs
@@ -64,6 +64,11 @@ pub trait Client {
         args: TerminalOutputRequest,
     ) -> impl Future<Output = Result<TerminalOutputResponse, Error>>;
 
+    fn release_terminal(
+        &self,
+        args: ReleaseTerminalRequest,
+    ) -> impl Future<Output = Result<(), Error>>;
+
     /// Handles session update notifications from the agent.
     ///
     /// This is a notification endpoint (no response expected) that receives
@@ -308,6 +313,14 @@ pub struct TerminalOutputResponse {
     pub signal: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(extend("x-side" = "client", "x-method" = "terminal/release"))]
+#[serde(rename_all = "camelCase")]
+pub struct ReleaseTerminalRequest {
+    pub session_id: SessionId,
+    pub terminal_id: TerminalId,
+}
+
 // Capabilities
 
 /// Capabilities supported by the client.
@@ -360,6 +373,8 @@ pub struct ClientMethodNames {
     pub terminal_new: &'static str,
     /// Method for getting terminals output.
     pub terminal_output: &'static str,
+    /// Method for releasing terminals.
+    pub terminal_release: &'static str,
 }
 
 /// Constant containing all client method names.
@@ -370,6 +385,7 @@ pub const CLIENT_METHOD_NAMES: ClientMethodNames = ClientMethodNames {
     fs_read_text_file: FS_READ_TEXT_FILE_METHOD_NAME,
     terminal_new: TERMINAL_NEW_METHOD_NAME,
     terminal_output: TERMINAL_OUTPUT_METHOD_NAME,
+    terminal_release: TERMINAL_RELEASE_METHOD_NAME,
 };
 
 /// Notification name for session updates.
@@ -384,6 +400,8 @@ pub(crate) const FS_READ_TEXT_FILE_METHOD_NAME: &str = "fs/read_text_file";
 pub(crate) const TERMINAL_NEW_METHOD_NAME: &str = "terminal/new";
 /// Method for getting terminals output.
 pub(crate) const TERMINAL_OUTPUT_METHOD_NAME: &str = "terminal/output";
+/// Method for releasing a terminal.
+pub(crate) const TERMINAL_RELEASE_METHOD_NAME: &str = "terminal/release";
 
 /// All possible requests that an agent can send to a client.
 ///
@@ -400,6 +418,7 @@ pub enum AgentRequest {
     RequestPermissionRequest(RequestPermissionRequest),
     NewTerminalRequest(NewTerminalRequest),
     TerminalOutputRequest(TerminalOutputRequest),
+    ReleaseTerminalRequest(ReleaseTerminalRequest),
 }
 
 /// All possible responses that a client can send to an agent.
@@ -417,6 +436,7 @@ pub enum ClientResponse {
     RequestPermissionResponse(RequestPermissionResponse),
     NewTerminalResponse(NewTerminalResponse),
     TerminalOutputResponse(TerminalOutputResponse),
+    ReleaseTerminalResponse,
 }
 
 /// All possible notifications that an agent can send to a client.

--- a/rust/client.rs
+++ b/rust/client.rs
@@ -54,26 +54,6 @@ pub trait Client {
         args: ReadTextFileRequest,
     ) -> impl Future<Output = Result<ReadTextFileResponse, Error>>;
 
-    fn create_terminal(
-        &self,
-        args: CreateTerminalRequest,
-    ) -> impl Future<Output = Result<CreateTerminalResponse, Error>>;
-
-    fn terminal_output(
-        &self,
-        args: TerminalOutputRequest,
-    ) -> impl Future<Output = Result<TerminalOutputResponse, Error>>;
-
-    fn release_terminal(
-        &self,
-        args: ReleaseTerminalRequest,
-    ) -> impl Future<Output = Result<(), Error>>;
-
-    fn wait_for_terminal_exit(
-        &self,
-        args: WaitForTerminalExitRequest,
-    ) -> impl Future<Output = Result<WaitForTerminalExitResponse, Error>>;
-
     /// Handles session update notifications from the agent.
     ///
     /// This is a notification endpoint (no response expected) that receives
@@ -89,6 +69,44 @@ pub trait Client {
         &self,
         args: SessionNotification,
     ) -> impl Future<Output = Result<(), Error>>;
+
+    // Experimental terminal support
+
+    /// **UNSTABLE**
+    ///
+    /// This method is not part of the spec, and may be removed or changed at any point.
+    #[doc(hidden)]
+    fn create_terminal(
+        &self,
+        args: CreateTerminalRequest,
+    ) -> impl Future<Output = Result<CreateTerminalResponse, Error>>;
+
+    /// **UNSTABLE**
+    ///
+    /// This method is not part of the spec, and may be removed or changed at any point.
+    #[doc(hidden)]
+    fn terminal_output(
+        &self,
+        args: TerminalOutputRequest,
+    ) -> impl Future<Output = Result<TerminalOutputResponse, Error>>;
+
+    /// **UNSTABLE**
+    ///
+    /// This method is not part of the spec, and may be removed or changed at any point.
+    #[doc(hidden)]
+    fn release_terminal(
+        &self,
+        args: ReleaseTerminalRequest,
+    ) -> impl Future<Output = Result<(), Error>>;
+
+    /// **UNSTABLE**
+    ///
+    /// This method is not part of the spec, and may be removed or changed at any point.
+    #[doc(hidden)]
+    fn wait_for_terminal_exit(
+        &self,
+        args: WaitForTerminalExitRequest,
+    ) -> impl Future<Output = Result<WaitForTerminalExitResponse, Error>>;
 }
 
 // Session updates
@@ -277,7 +295,7 @@ impl std::fmt::Display for TerminalId {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[schemars(extend("x-side" = "client", "x-method" = "terminal/create"))]
+#[schemars(extend("x-docs-ignore" = true))]
 #[serde(rename_all = "camelCase")]
 pub struct CreateTerminalRequest {
     pub session_id: SessionId,
@@ -293,14 +311,14 @@ pub struct CreateTerminalRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[schemars(extend("x-side" = "client", "x-method" = "terminal/create"))]
+#[schemars(extend("x-docs-ignore" = true))]
 #[serde(rename_all = "camelCase")]
 pub struct CreateTerminalResponse {
     pub terminal_id: TerminalId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[schemars(extend("x-side" = "client", "x-method" = "terminal/output"))]
+#[schemars(extend("x-docs-ignore" = true))]
 #[serde(rename_all = "camelCase")]
 pub struct TerminalOutputRequest {
     pub session_id: SessionId,
@@ -308,7 +326,7 @@ pub struct TerminalOutputRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[schemars(extend("x-side" = "client", "x-method" = "terminal/output"))]
+#[schemars(extend("x-docs-ignore" = true))]
 #[serde(rename_all = "camelCase")]
 pub struct TerminalOutputResponse {
     pub output: String,
@@ -317,7 +335,7 @@ pub struct TerminalOutputResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[schemars(extend("x-side" = "client", "x-method" = "terminal/release"))]
+#[schemars(extend("x-docs-ignore" = true))]
 #[serde(rename_all = "camelCase")]
 pub struct ReleaseTerminalRequest {
     pub session_id: SessionId,
@@ -325,7 +343,7 @@ pub struct ReleaseTerminalRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[schemars(extend("x-side" = "client", "x-method" = "terminal/wait_for_exit"))]
+#[schemars(extend("x-docs-ignore" = true))]
 #[serde(rename_all = "camelCase")]
 pub struct WaitForTerminalExitRequest {
     pub session_id: SessionId,
@@ -333,7 +351,7 @@ pub struct WaitForTerminalExitRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[schemars(extend("x-side" = "client", "x-method" = "terminal/wait_for_exit"))]
+#[schemars(extend("x-docs-ignore" = true))]
 #[serde(rename_all = "camelCase")]
 pub struct WaitForTerminalExitResponse {
     #[serde(flatten)]
@@ -341,6 +359,7 @@ pub struct WaitForTerminalExitResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(extend("x-docs-ignore" = true))]
 #[serde(rename_all = "camelCase")]
 pub struct TerminalExitStatus {
     pub exit_code: Option<u32>,
@@ -362,7 +381,12 @@ pub struct ClientCapabilities {
     /// Determines which file operations the agent can request.
     #[serde(default)]
     pub fs: FileSystemCapability,
+
+    /// **UNSTABLE**
+    ///
+    /// This capability is not part of the spec yet, and may be removed or changed at any point.
     #[serde(default)]
+    #[doc(hidden)]
     pub terminal: bool,
 }
 

--- a/rust/example_client.rs
+++ b/rust/example_client.rs
@@ -40,6 +40,20 @@ impl acp::Client for ExampleClient {
         Err(acp::Error::method_not_found())
     }
 
+    async fn new_terminal(
+        &self,
+        _args: acp::NewTerminalRequest,
+    ) -> anyhow::Result<acp::NewTerminalResponse, acp::Error> {
+        Err(acp::Error::method_not_found())
+    }
+
+    async fn terminal_output(
+        &self,
+        _args: acp::TerminalOutputRequest,
+    ) -> anyhow::Result<acp::TerminalOutputResponse, acp::Error> {
+        Err(acp::Error::method_not_found())
+    }
+
     async fn session_notification(
         &self,
         args: acp::SessionNotification,

--- a/rust/example_client.rs
+++ b/rust/example_client.rs
@@ -61,6 +61,13 @@ impl acp::Client for ExampleClient {
         Err(acp::Error::method_not_found())
     }
 
+    async fn wait_for_terminal_exit(
+        &self,
+        _args: acp::WaitForTerminalExitRequest,
+    ) -> anyhow::Result<acp::WaitForTerminalExitResponse, acp::Error> {
+        Err(acp::Error::method_not_found())
+    }
+
     async fn session_notification(
         &self,
         args: acp::SessionNotification,

--- a/rust/example_client.rs
+++ b/rust/example_client.rs
@@ -54,6 +54,13 @@ impl acp::Client for ExampleClient {
         Err(acp::Error::method_not_found())
     }
 
+    async fn release_terminal(
+        &self,
+        _args: acp::ReleaseTerminalRequest,
+    ) -> anyhow::Result<(), acp::Error> {
+        Err(acp::Error::method_not_found())
+    }
+
     async fn session_notification(
         &self,
         args: acp::SessionNotification,

--- a/rust/example_client.rs
+++ b/rust/example_client.rs
@@ -40,10 +40,10 @@ impl acp::Client for ExampleClient {
         Err(acp::Error::method_not_found())
     }
 
-    async fn new_terminal(
+    async fn create_terminal(
         &self,
-        _args: acp::NewTerminalRequest,
-    ) -> anyhow::Result<acp::NewTerminalResponse, acp::Error> {
+        _args: acp::CreateTerminalRequest,
+    ) -> Result<acp::CreateTerminalResponse, acp::Error> {
         Err(acp::Error::method_not_found())
     }
 

--- a/rust/example_client.rs
+++ b/rust/example_client.rs
@@ -40,6 +40,7 @@ impl acp::Client for ExampleClient {
         Err(acp::Error::method_not_found())
     }
 
+    #[cfg(feature = "unstable")]
     async fn create_terminal(
         &self,
         _args: acp::CreateTerminalRequest,
@@ -47,6 +48,7 @@ impl acp::Client for ExampleClient {
         Err(acp::Error::method_not_found())
     }
 
+    #[cfg(feature = "unstable")]
     async fn terminal_output(
         &self,
         _args: acp::TerminalOutputRequest,
@@ -54,6 +56,7 @@ impl acp::Client for ExampleClient {
         Err(acp::Error::method_not_found())
     }
 
+    #[cfg(feature = "unstable")]
     async fn release_terminal(
         &self,
         _args: acp::ReleaseTerminalRequest,
@@ -61,6 +64,7 @@ impl acp::Client for ExampleClient {
         Err(acp::Error::method_not_found())
     }
 
+    #[cfg(feature = "unstable")]
     async fn wait_for_terminal_exit(
         &self,
         _args: acp::WaitForTerminalExitRequest,

--- a/rust/markdown_generator.rs
+++ b/rust/markdown_generator.rs
@@ -644,6 +644,8 @@ impl SideDocs {
             "fs/write_text_file" => self.client_methods.get("write_text_file").unwrap(),
             "fs/read_text_file" => self.client_methods.get("read_text_file").unwrap(),
             "session/update" => self.client_methods.get("session_notification").unwrap(),
+            "terminal/new" => self.client_methods.get("new_terminal").unwrap(),
+            "terminal/output" => self.client_methods.get("terminal_output").unwrap(),
             _ => panic!("Introduced a method? Add it here :)"),
         }
     }

--- a/rust/markdown_generator.rs
+++ b/rust/markdown_generator.rs
@@ -644,7 +644,7 @@ impl SideDocs {
             "fs/write_text_file" => self.client_methods.get("write_text_file").unwrap(),
             "fs/read_text_file" => self.client_methods.get("read_text_file").unwrap(),
             "session/update" => self.client_methods.get("session_notification").unwrap(),
-            "terminal/new" => self.client_methods.get("new_terminal").unwrap(),
+            "terminal/create" => self.client_methods.get("create_terminal").unwrap(),
             "terminal/output" => self.client_methods.get("terminal_output").unwrap(),
             "terminal/release" => self.client_methods.get("release_terminal").unwrap(),
             "terminal/wait_for_exit" => self.client_methods.get("wait_for_terminal_exit").unwrap(),

--- a/rust/markdown_generator.rs
+++ b/rust/markdown_generator.rs
@@ -646,6 +646,7 @@ impl SideDocs {
             "session/update" => self.client_methods.get("session_notification").unwrap(),
             "terminal/new" => self.client_methods.get("new_terminal").unwrap(),
             "terminal/output" => self.client_methods.get("terminal_output").unwrap(),
+            "terminal/release" => self.client_methods.get("release_terminal").unwrap(),
             _ => panic!("Introduced a method? Add it here :)"),
         }
     }

--- a/rust/markdown_generator.rs
+++ b/rust/markdown_generator.rs
@@ -647,6 +647,7 @@ impl SideDocs {
             "terminal/new" => self.client_methods.get("new_terminal").unwrap(),
             "terminal/output" => self.client_methods.get("terminal_output").unwrap(),
             "terminal/release" => self.client_methods.get("release_terminal").unwrap(),
+            "terminal/wait_for_exit" => self.client_methods.get("wait_for_terminal_exit").unwrap(),
             _ => panic!("Introduced a method? Add it here :)"),
         }
     }

--- a/rust/rpc_tests.rs
+++ b/rust/rpc_tests.rs
@@ -82,6 +82,13 @@ impl Client for TestClient {
     async fn release_terminal(&self, _args: ReleaseTerminalRequest) -> Result<(), Error> {
         unimplemented!()
     }
+
+    async fn wait_for_terminal_exit(
+        &self,
+        _args: WaitForTerminalExitRequest,
+    ) -> Result<WaitForTerminalExitResponse, Error> {
+        unimplemented!()
+    }
 }
 
 #[derive(Clone)]

--- a/rust/rpc_tests.rs
+++ b/rust/rpc_tests.rs
@@ -68,6 +68,7 @@ impl Client for TestClient {
         Ok(())
     }
 
+    #[cfg(feature = "unstable")]
     async fn create_terminal(
         &self,
         _args: CreateTerminalRequest,
@@ -75,6 +76,7 @@ impl Client for TestClient {
         unimplemented!()
     }
 
+    #[cfg(feature = "unstable")]
     async fn terminal_output(
         &self,
         _args: TerminalOutputRequest,
@@ -82,10 +84,12 @@ impl Client for TestClient {
         unimplemented!()
     }
 
+    #[cfg(feature = "unstable")]
     async fn release_terminal(&self, _args: ReleaseTerminalRequest) -> Result<(), Error> {
         unimplemented!()
     }
 
+    #[cfg(feature = "unstable")]
     async fn wait_for_terminal_exit(
         &self,
         _args: WaitForTerminalExitRequest,

--- a/rust/rpc_tests.rs
+++ b/rust/rpc_tests.rs
@@ -68,7 +68,10 @@ impl Client for TestClient {
         Ok(())
     }
 
-    async fn new_terminal(&self, _args: NewTerminalRequest) -> Result<NewTerminalResponse, Error> {
+    async fn create_terminal(
+        &self,
+        _args: CreateTerminalRequest,
+    ) -> Result<CreateTerminalResponse, Error> {
         unimplemented!()
     }
 

--- a/rust/rpc_tests.rs
+++ b/rust/rpc_tests.rs
@@ -67,6 +67,17 @@ impl Client for TestClient {
         self.session_notifications.lock().unwrap().push(args);
         Ok(())
     }
+
+    async fn new_terminal(&self, _args: NewTerminalRequest) -> Result<NewTerminalResponse, Error> {
+        unimplemented!()
+    }
+
+    async fn terminal_output(
+        &self,
+        _args: TerminalOutputRequest,
+    ) -> Result<TerminalOutputResponse, Error> {
+        unimplemented!()
+    }
 }
 
 #[derive(Clone)]

--- a/rust/rpc_tests.rs
+++ b/rust/rpc_tests.rs
@@ -78,6 +78,10 @@ impl Client for TestClient {
     ) -> Result<TerminalOutputResponse, Error> {
         unimplemented!()
     }
+
+    async fn release_terminal(&self, _args: ReleaseTerminalRequest) -> Result<(), Error> {
+        unimplemented!()
+    }
 }
 
 #[derive(Clone)]

--- a/rust/tool_call.rs
+++ b/rust/tool_call.rs
@@ -9,7 +9,7 @@ use std::{path::PathBuf, sync::Arc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{ContentBlock, Error, TerminalId};
+use crate::{ContentBlock, Error};
 
 /// Represents a tool call that the language model has requested.
 ///
@@ -275,7 +275,8 @@ pub enum ToolCallContent {
         diff: Diff,
     },
     #[serde(rename_all = "camelCase")]
-    Terminal { terminal_id: TerminalId },
+    #[cfg(feature = "unstable")]
+    Terminal { terminal_id: crate::TerminalId },
 }
 
 impl<T: Into<ContentBlock>> From<T> for ToolCallContent {

--- a/rust/tool_call.rs
+++ b/rust/tool_call.rs
@@ -9,7 +9,7 @@ use std::{path::PathBuf, sync::Arc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{ContentBlock, Error};
+use crate::{ContentBlock, Error, TerminalId};
 
 /// Represents a tool call that the language model has requested.
 ///
@@ -274,6 +274,8 @@ pub enum ToolCallContent {
         #[serde(flatten)]
         diff: Diff,
     },
+    #[serde(rename_all = "camelCase")]
+    Terminal { terminal_id: TerminalId },
 }
 
 impl<T: Into<ContentBlock>> From<T> for ToolCallContent {

--- a/schema/meta.json
+++ b/schema/meta.json
@@ -12,7 +12,7 @@
     "fs_write_text_file": "fs/write_text_file",
     "session_request_permission": "session/request_permission",
     "session_update": "session/update",
-    "terminal_new": "terminal/new",
+    "terminal_create": "terminal/create",
     "terminal_output": "terminal/output",
     "terminal_release": "terminal/release",
     "terminal_wait_for_exit": "terminal/wait_for_exit"

--- a/schema/meta.json
+++ b/schema/meta.json
@@ -13,7 +13,8 @@
     "session_request_permission": "session/request_permission",
     "session_update": "session/update",
     "terminal_new": "terminal/new",
-    "terminal_output": "terminal/output"
+    "terminal_output": "terminal/output",
+    "terminal_release": "terminal/release"
   },
   "version": 1
 }

--- a/schema/meta.json
+++ b/schema/meta.json
@@ -14,7 +14,8 @@
     "session_update": "session/update",
     "terminal_new": "terminal/new",
     "terminal_output": "terminal/output",
-    "terminal_release": "terminal/release"
+    "terminal_release": "terminal/release",
+    "terminal_wait_for_exit": "terminal/wait_for_exit"
   },
   "version": 1
 }

--- a/schema/meta.json
+++ b/schema/meta.json
@@ -11,7 +11,9 @@
     "fs_read_text_file": "fs/read_text_file",
     "fs_write_text_file": "fs/write_text_file",
     "session_request_permission": "session/request_permission",
-    "session_update": "session/update"
+    "session_update": "session/update",
+    "terminal_new": "terminal/new",
+    "terminal_output": "terminal/output"
   },
   "version": 1
 }

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -210,6 +210,7 @@
         },
         "terminal": {
           "default": false,
+          "description": "**UNSTABLE**\n\nThis capability is not part of the spec yet, and may be removed or changed at any point.",
           "type": "boolean"
         }
       },
@@ -466,8 +467,7 @@
       },
       "required": ["sessionId", "command"],
       "type": "object",
-      "x-method": "terminal/create",
-      "x-side": "client"
+      "x-docs-ignore": true
     },
     "CreateTerminalResponse": {
       "properties": {
@@ -477,8 +477,7 @@
       },
       "required": ["terminalId"],
       "type": "object",
-      "x-method": "terminal/create",
-      "x-side": "client"
+      "x-docs-ignore": true
     },
     "EmbeddedResource": {
       "description": "The contents of a resource, embedded into a prompt or tool call result.",
@@ -945,8 +944,7 @@
       },
       "required": ["sessionId", "terminalId"],
       "type": "object",
-      "x-method": "terminal/release",
-      "x-side": "client"
+      "x-docs-ignore": true
     },
     "RequestPermissionOutcome": {
       "description": "The outcome of a permission request.",
@@ -1292,7 +1290,8 @@
           "type": ["string", "null"]
         }
       },
-      "type": "object"
+      "type": "object",
+      "x-docs-ignore": true
     },
     "TerminalOutputRequest": {
       "properties": {
@@ -1305,8 +1304,7 @@
       },
       "required": ["sessionId", "terminalId"],
       "type": "object",
-      "x-method": "terminal/output",
-      "x-side": "client"
+      "x-docs-ignore": true
     },
     "TerminalOutputResponse": {
       "properties": {
@@ -1329,8 +1327,7 @@
       },
       "required": ["output", "truncated"],
       "type": "object",
-      "x-method": "terminal/output",
-      "x-side": "client"
+      "x-docs-ignore": true
     },
     "TextContent": {
       "description": "Text provided to or from an LLM.",
@@ -1631,8 +1628,7 @@
       },
       "required": ["sessionId", "terminalId"],
       "type": "object",
-      "x-method": "terminal/wait_for_exit",
-      "x-side": "client"
+      "x-docs-ignore": true
     },
     "WaitForTerminalExitResponse": {
       "properties": {
@@ -1646,8 +1642,7 @@
         }
       },
       "type": "object",
-      "x-method": "terminal/wait_for_exit",
-      "x-side": "client"
+      "x-docs-ignore": true
     },
     "WriteTextFileRequest": {
       "description": "Request to write content to a text file.\n\nOnly available if the client supports the `fs.writeTextFile` capability.",

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -45,8 +45,8 @@
           "title": "RequestPermissionRequest"
         },
         {
-          "$ref": "#/$defs/NewTerminalRequest",
-          "title": "NewTerminalRequest"
+          "$ref": "#/$defs/CreateTerminalRequest",
+          "title": "CreateTerminalRequest"
         },
         {
           "$ref": "#/$defs/TerminalOutputRequest",
@@ -266,8 +266,8 @@
           "title": "RequestPermissionResponse"
         },
         {
-          "$ref": "#/$defs/NewTerminalResponse",
-          "title": "NewTerminalResponse"
+          "$ref": "#/$defs/CreateTerminalResponse",
+          "title": "CreateTerminalResponse"
         },
         {
           "$ref": "#/$defs/TerminalOutputResponse",
@@ -434,6 +434,51 @@
           "type": "object"
         }
       ]
+    },
+    "CreateTerminalRequest": {
+      "properties": {
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "command": {
+          "type": "string"
+        },
+        "cwd": {
+          "type": ["string", "null"]
+        },
+        "env": {
+          "items": {
+            "$ref": "#/$defs/EnvVariable"
+          },
+          "type": "array"
+        },
+        "outputByteLimit": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": ["integer", "null"]
+        },
+        "sessionId": {
+          "$ref": "#/$defs/SessionId"
+        }
+      },
+      "required": ["sessionId", "command"],
+      "type": "object",
+      "x-method": "terminal/create",
+      "x-side": "client"
+    },
+    "CreateTerminalResponse": {
+      "properties": {
+        "terminalId": {
+          "type": "string"
+        }
+      },
+      "required": ["terminalId"],
+      "type": "object",
+      "x-method": "terminal/create",
+      "x-side": "client"
     },
     "EmbeddedResource": {
       "description": "The contents of a resource, embedded into a prompt or tool call result.",
@@ -667,51 +712,6 @@
       "type": "object",
       "x-method": "session/new",
       "x-side": "agent"
-    },
-    "NewTerminalRequest": {
-      "properties": {
-        "args": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "command": {
-          "type": "string"
-        },
-        "cwd": {
-          "type": ["string", "null"]
-        },
-        "env": {
-          "items": {
-            "$ref": "#/$defs/EnvVariable"
-          },
-          "type": "array"
-        },
-        "outputByteLimit": {
-          "format": "uint64",
-          "minimum": 0,
-          "type": ["integer", "null"]
-        },
-        "sessionId": {
-          "$ref": "#/$defs/SessionId"
-        }
-      },
-      "required": ["sessionId", "command"],
-      "type": "object",
-      "x-method": "terminal/new",
-      "x-side": "client"
-    },
-    "NewTerminalResponse": {
-      "properties": {
-        "terminalId": {
-          "type": "string"
-        }
-      },
-      "required": ["terminalId"],
-      "type": "object",
-      "x-method": "terminal/new",
-      "x-side": "client"
     },
     "PermissionOption": {
       "description": "An option presented to the user when requesting permission.",

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -51,6 +51,10 @@
         {
           "$ref": "#/$defs/TerminalOutputRequest",
           "title": "TerminalOutputRequest"
+        },
+        {
+          "$ref": "#/$defs/ReleaseTerminalRequest",
+          "title": "ReleaseTerminalRequest"
         }
       ],
       "description": "All possible requests that an agent can send to a client.\n\nThis enum is used internally for routing RPC requests. You typically won't need\nto use this directly - instead, use the methods on the [`Client`] trait.\n\nThis enum encompasses all method calls from agent to client.",
@@ -264,6 +268,10 @@
         {
           "$ref": "#/$defs/TerminalOutputResponse",
           "title": "TerminalOutputResponse"
+        },
+        {
+          "title": "ReleaseTerminalResponse",
+          "type": "null"
         }
       ],
       "description": "All possible responses that a client can send to an agent.\n\nThis enum is used internally for routing RPC responses. You typically won't need\nto use this directly - the responses are handled automatically by the connection.\n\nThese are responses to the corresponding AgentRequest variants.",
@@ -917,6 +925,20 @@
       },
       "required": ["content"],
       "type": "object"
+    },
+    "ReleaseTerminalRequest": {
+      "properties": {
+        "sessionId": {
+          "$ref": "#/$defs/SessionId"
+        },
+        "terminalId": {
+          "type": "string"
+        }
+      },
+      "required": ["sessionId", "terminalId"],
+      "type": "object",
+      "x-method": "terminal/release",
+      "x-side": "client"
     },
     "RequestPermissionOutcome": {
       "description": "The outcome of a permission request.",

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -43,6 +43,14 @@
         {
           "$ref": "#/$defs/RequestPermissionRequest",
           "title": "RequestPermissionRequest"
+        },
+        {
+          "$ref": "#/$defs/NewTerminalRequest",
+          "title": "NewTerminalRequest"
+        },
+        {
+          "$ref": "#/$defs/TerminalOutputRequest",
+          "title": "TerminalOutputRequest"
         }
       ],
       "description": "All possible requests that an agent can send to a client.\n\nThis enum is used internally for routing RPC requests. You typically won't need\nto use this directly - instead, use the methods on the [`Client`] trait.\n\nThis enum encompasses all method calls from agent to client.",
@@ -191,6 +199,10 @@
             "writeTextFile": false
           },
           "description": "File system capabilities supported by the client.\nDetermines which file operations the agent can request."
+        },
+        "terminal": {
+          "default": false,
+          "type": "boolean"
         }
       },
       "type": "object"
@@ -244,6 +256,14 @@
         {
           "$ref": "#/$defs/RequestPermissionResponse",
           "title": "RequestPermissionResponse"
+        },
+        {
+          "$ref": "#/$defs/NewTerminalResponse",
+          "title": "NewTerminalResponse"
+        },
+        {
+          "$ref": "#/$defs/TerminalOutputResponse",
+          "title": "TerminalOutputResponse"
         }
       ],
       "description": "All possible responses that a client can send to an agent.\n\nThis enum is used internally for routing RPC responses. You typically won't need\nto use this directly - the responses are handled automatically by the connection.\n\nThese are responses to the corresponding AgentRequest variants.",
@@ -498,7 +518,8 @@
             "fs": {
               "readTextFile": false,
               "writeTextFile": false
-            }
+            },
+            "terminal": false
           },
           "description": "Capabilities supported by the client."
         },
@@ -630,6 +651,51 @@
       "type": "object",
       "x-method": "session/new",
       "x-side": "agent"
+    },
+    "NewTerminalRequest": {
+      "properties": {
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "command": {
+          "type": "string"
+        },
+        "cwd": {
+          "type": ["string", "null"]
+        },
+        "env": {
+          "items": {
+            "$ref": "#/$defs/EnvVariable"
+          },
+          "type": "array"
+        },
+        "outputByteLimit": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": ["integer", "null"]
+        },
+        "sessionId": {
+          "$ref": "#/$defs/SessionId"
+        }
+      },
+      "required": ["sessionId", "command"],
+      "type": "object",
+      "x-method": "terminal/new",
+      "x-side": "client"
+    },
+    "NewTerminalResponse": {
+      "properties": {
+        "terminalId": {
+          "type": "string"
+        }
+      },
+      "required": ["terminalId"],
+      "type": "object",
+      "x-method": "terminal/new",
+      "x-side": "client"
     },
     "PermissionOption": {
       "description": "An option presented to the user when requesting permission.",
@@ -1185,6 +1251,45 @@
         }
       ]
     },
+    "TerminalOutputRequest": {
+      "properties": {
+        "sessionId": {
+          "$ref": "#/$defs/SessionId"
+        },
+        "terminalId": {
+          "type": "string"
+        }
+      },
+      "required": ["sessionId", "terminalId"],
+      "type": "object",
+      "x-method": "terminal/output",
+      "x-side": "client"
+    },
+    "TerminalOutputResponse": {
+      "properties": {
+        "exitCode": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": ["integer", "null"]
+        },
+        "finished": {
+          "type": "boolean"
+        },
+        "output": {
+          "type": "string"
+        },
+        "signal": {
+          "type": ["string", "null"]
+        },
+        "truncated": {
+          "type": "boolean"
+        }
+      },
+      "required": ["output", "truncated", "finished"],
+      "type": "object",
+      "x-method": "terminal/output",
+      "x-side": "client"
+    },
     "TextContent": {
       "description": "Text provided to or from an LLM.",
       "properties": {
@@ -1303,6 +1408,19 @@
             }
           },
           "required": ["type", "path", "newText"],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "terminalId": {
+              "type": "string"
+            },
+            "type": {
+              "const": "terminal",
+              "type": "string"
+            }
+          },
+          "required": ["type", "terminalId"],
           "type": "object"
         }
       ]

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -55,6 +55,10 @@
         {
           "$ref": "#/$defs/ReleaseTerminalRequest",
           "title": "ReleaseTerminalRequest"
+        },
+        {
+          "$ref": "#/$defs/WaitForTerminalExitRequest",
+          "title": "WaitForTerminalExitRequest"
         }
       ],
       "description": "All possible requests that an agent can send to a client.\n\nThis enum is used internally for routing RPC requests. You typically won't need\nto use this directly - instead, use the methods on the [`Client`] trait.\n\nThis enum encompasses all method calls from agent to client.",
@@ -272,6 +276,10 @@
         {
           "title": "ReleaseTerminalResponse",
           "type": "null"
+        },
+        {
+          "$ref": "#/$defs/WaitForTerminalExitResponse",
+          "title": "WaitForTerminalExitResponse"
         }
       ],
       "description": "All possible responses that a client can send to an agent.\n\nThis enum is used internally for routing RPC responses. You typically won't need\nto use this directly - the responses are handled automatically by the connection.\n\nThese are responses to the corresponding AgentRequest variants.",
@@ -1273,6 +1281,19 @@
         }
       ]
     },
+    "TerminalExitStatus": {
+      "properties": {
+        "exitCode": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": ["integer", "null"]
+        },
+        "signal": {
+          "type": ["string", "null"]
+        }
+      },
+      "type": "object"
+    },
     "TerminalOutputRequest": {
       "properties": {
         "sessionId": {
@@ -1289,25 +1310,24 @@
     },
     "TerminalOutputResponse": {
       "properties": {
-        "exitCode": {
-          "format": "uint32",
-          "minimum": 0,
-          "type": ["integer", "null"]
-        },
-        "finished": {
-          "type": "boolean"
+        "exitStatus": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TerminalExitStatus"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "output": {
           "type": "string"
-        },
-        "signal": {
-          "type": ["string", "null"]
         },
         "truncated": {
           "type": "boolean"
         }
       },
-      "required": ["output", "truncated", "finished"],
+      "required": ["output", "truncated"],
       "type": "object",
       "x-method": "terminal/output",
       "x-side": "client"
@@ -1599,6 +1619,35 @@
           "type": "string"
         }
       ]
+    },
+    "WaitForTerminalExitRequest": {
+      "properties": {
+        "sessionId": {
+          "$ref": "#/$defs/SessionId"
+        },
+        "terminalId": {
+          "type": "string"
+        }
+      },
+      "required": ["sessionId", "terminalId"],
+      "type": "object",
+      "x-method": "terminal/wait_for_exit",
+      "x-side": "client"
+    },
+    "WaitForTerminalExitResponse": {
+      "properties": {
+        "exitCode": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": ["integer", "null"]
+        },
+        "signal": {
+          "type": ["string", "null"]
+        }
+      },
+      "type": "object",
+      "x-method": "terminal/wait_for_exit",
+      "x-side": "client"
     },
     "WriteTextFileRequest": {
       "description": "Request to write content to a text file.\n\nOnly available if the client supports the `fs.writeTextFile` capability.",

--- a/typescript/acp.ts
+++ b/typescript/acp.ts
@@ -293,28 +293,28 @@ export class ClientSideConnection implements Agent {
         case schema.CLIENT_METHODS.terminal_create: {
           const validatedParams =
             schema.createTerminalRequestSchema.parse(params);
-          return client.createTerminal(
+          return client.createTerminal?.(
             validatedParams as schema.CreateTerminalRequest,
           );
         }
         case schema.CLIENT_METHODS.terminal_output: {
           const validatedParams =
             schema.terminalOutputRequestSchema.parse(params);
-          return client.terminalOutput(
+          return client.terminalOutput?.(
             validatedParams as schema.TerminalOutputRequest,
           );
         }
         case schema.CLIENT_METHODS.terminal_release: {
           const validatedParams =
             schema.releaseTerminalRequestSchema.parse(params);
-          return client.releaseTerminal(
+          return client.releaseTerminal?.(
             validatedParams as schema.ReleaseTerminalRequest,
           );
         }
         case schema.CLIENT_METHODS.terminal_wait_for_exit: {
           const validatedParams =
             schema.waitForTerminalExitRequestSchema.parse(params);
-          return client.waitForTerminalExit(
+          return client.waitForTerminalExit?.(
             validatedParams as schema.WaitForTerminalExitRequest,
           );
         }
@@ -798,30 +798,38 @@ export interface Client {
   readTextFile(
     params: schema.ReadTextFileRequest,
   ): Promise<schema.ReadTextFileResponse>;
+
   /**
-   * Creates a new terminal instance in the client's environment.
+   *  @internal **UNSTABLE**
    *
-   * Only available if the client advertises the `terminal` capability.
-   * Allows the agent to spawn and interact with terminal processes.
-   *
-   * See protocol docs: [Client](https://agentclientprotocol.com/protocol/overview#client)
+   * This method is not part of the spec, and may be removed or changed at any point.
    */
-  createTerminal(
+  createTerminal?(
     params: schema.CreateTerminalRequest,
   ): Promise<schema.CreateTerminalResponse>;
+
   /**
-   * Retrieves output from a previously created terminal.
+   *  @internal **UNSTABLE**
    *
-   * Only available if the client advertises the `terminal` capability.
-   * Returns the terminal's output buffer and exit status if available.
-   *
-   * See protocol docs: [Client](https://agentclientprotocol.com/protocol/overview#client)
+   * This method is not part of the spec, and may be removed or changed at any point.
    */
-  terminalOutput(
+  terminalOutput?(
     params: schema.TerminalOutputRequest,
   ): Promise<schema.TerminalOutputResponse>;
-  releaseTerminal(params: schema.ReleaseTerminalRequest): Promise<void>;
-  waitForTerminalExit(
+
+  /**
+   *  @internal **UNSTABLE**
+   *
+   * This method is not part of the spec, and may be removed or changed at any point.
+   */
+  releaseTerminal?(params: schema.ReleaseTerminalRequest): Promise<void>;
+
+  /**
+   *  @internal **UNSTABLE**
+   *
+   * This method is not part of the spec, and may be removed or changed at any point.
+   */
+  waitForTerminalExit?(
     params: schema.WaitForTerminalExitRequest,
   ): Promise<schema.WaitForTerminalExitResponse>;
 }

--- a/typescript/acp.ts
+++ b/typescript/acp.ts
@@ -173,6 +173,13 @@ export class AgentSideConnection implements Client {
     );
   }
 
+  async releaseTerminal(params: schema.ReleaseTerminalRequest): Promise<void> {
+    return await this.#connection.sendRequest(
+      schema.CLIENT_METHODS.terminal_release,
+      params,
+    );
+  }
+
   /**
    * Writes content to a text file in the client's file system.
    *
@@ -267,6 +274,13 @@ export class ClientSideConnection implements Agent {
             schema.terminalOutputRequestSchema.parse(params);
           return client.terminalOutput(
             validatedParams as schema.TerminalOutputRequest,
+          );
+        }
+        case schema.CLIENT_METHODS.terminal_release: {
+          const validatedParams =
+            schema.releaseTerminalRequestSchema.parse(params);
+          return client.releaseTerminal(
+            validatedParams as schema.ReleaseTerminalRequest,
           );
         }
         default:
@@ -771,6 +785,7 @@ export interface Client {
   terminalOutput(
     params: schema.TerminalOutputRequest,
   ): Promise<schema.TerminalOutputResponse>;
+  releaseTerminal(params: schema.ReleaseTerminalRequest): Promise<void>;
 }
 
 /**

--- a/typescript/acp.ts
+++ b/typescript/acp.ts
@@ -147,11 +147,11 @@ export class AgentSideConnection implements Client {
    *
    * See protocol docs: [Client](https://agentclientprotocol.com/protocol/overview#client)
    */
-  async newTerminal(
-    params: schema.NewTerminalRequest,
-  ): Promise<schema.NewTerminalResponse> {
+  async createTerminal(
+    params: schema.CreateTerminalRequest,
+  ): Promise<schema.CreateTerminalResponse> {
     return await this.#connection.sendRequest(
-      schema.CLIENT_METHODS.terminal_new,
+      schema.CLIENT_METHODS.terminal_create,
       params,
     );
   }
@@ -272,10 +272,11 @@ export class ClientSideConnection implements Agent {
             validatedParams as schema.SessionNotification,
           );
         }
-        case schema.CLIENT_METHODS.terminal_new: {
-          const validatedParams = schema.newTerminalRequestSchema.parse(params);
-          return client.newTerminal(
-            validatedParams as schema.NewTerminalRequest,
+        case schema.CLIENT_METHODS.terminal_create: {
+          const validatedParams =
+            schema.createTerminalRequestSchema.parse(params);
+          return client.createTerminal(
+            validatedParams as schema.CreateTerminalRequest,
           );
         }
         case schema.CLIENT_METHODS.terminal_output: {
@@ -458,11 +459,11 @@ type AnyError = {
 
 type Result<T> =
   | {
-    result: T;
-  }
+      result: T;
+    }
   | {
-    error: ErrorResponse;
-  };
+      error: ErrorResponse;
+    };
 
 type ErrorResponse = {
   code: number;
@@ -787,9 +788,9 @@ export interface Client {
    *
    * See protocol docs: [Client](https://agentclientprotocol.com/protocol/overview#client)
    */
-  newTerminal(
-    params: schema.NewTerminalRequest,
-  ): Promise<schema.NewTerminalResponse>;
+  createTerminal(
+    params: schema.CreateTerminalRequest,
+  ): Promise<schema.CreateTerminalResponse>;
   /**
    * Retrieves output from a previously created terminal.
    *

--- a/typescript/acp.ts
+++ b/typescript/acp.ts
@@ -180,6 +180,15 @@ export class AgentSideConnection implements Client {
     );
   }
 
+  async waitForTerminalExit(
+    params: schema.WaitForTerminalExitRequest,
+  ): Promise<schema.WaitForTerminalExitResponse> {
+    return await this.#connection.sendRequest(
+      schema.CLIENT_METHODS.terminal_wait_for_exit,
+      params,
+    );
+  }
+
   /**
    * Writes content to a text file in the client's file system.
    *
@@ -281,6 +290,13 @@ export class ClientSideConnection implements Agent {
             schema.releaseTerminalRequestSchema.parse(params);
           return client.releaseTerminal(
             validatedParams as schema.ReleaseTerminalRequest,
+          );
+        }
+        case schema.CLIENT_METHODS.terminal_wait_for_exit: {
+          const validatedParams =
+            schema.waitForTerminalExitRequestSchema.parse(params);
+          return client.waitForTerminalExit(
+            validatedParams as schema.WaitForTerminalExitRequest,
           );
         }
         default:
@@ -442,11 +458,11 @@ type AnyError = {
 
 type Result<T> =
   | {
-      result: T;
-    }
+    result: T;
+  }
   | {
-      error: ErrorResponse;
-    };
+    error: ErrorResponse;
+  };
 
 type ErrorResponse = {
   code: number;
@@ -786,6 +802,9 @@ export interface Client {
     params: schema.TerminalOutputRequest,
   ): Promise<schema.TerminalOutputResponse>;
   releaseTerminal(params: schema.ReleaseTerminalRequest): Promise<void>;
+  waitForTerminalExit(
+    params: schema.WaitForTerminalExitRequest,
+  ): Promise<schema.WaitForTerminalExitResponse>;
 }
 
 /**

--- a/typescript/acp.ts
+++ b/typescript/acp.ts
@@ -140,6 +140,40 @@ export class AgentSideConnection implements Client {
   }
 
   /**
+   * Creates a new terminal instance in the client's environment.
+   *
+   * Only available if the client advertises the `terminal` capability.
+   * Allows the agent to spawn and interact with terminal processes.
+   *
+   * See protocol docs: [Client](https://agentclientprotocol.com/protocol/overview#client)
+   */
+  async newTerminal(
+    params: schema.NewTerminalRequest,
+  ): Promise<schema.NewTerminalResponse> {
+    return await this.#connection.sendRequest(
+      schema.CLIENT_METHODS.terminal_new,
+      params,
+    );
+  }
+
+  /**
+   * Retrieves output from a previously created terminal.
+   *
+   * Only available if the client advertises the `terminal` capability.
+   * Returns the terminal's output buffer and exit status if available.
+   *
+   * See protocol docs: [Client](https://agentclientprotocol.com/protocol/overview#client)
+   */
+  async terminalOutput(
+    params: schema.TerminalOutputRequest,
+  ): Promise<schema.TerminalOutputResponse> {
+    return await this.#connection.sendRequest(
+      schema.CLIENT_METHODS.terminal_output,
+      params,
+    );
+  }
+
+  /**
    * Writes content to a text file in the client's file system.
    *
    * Only available if the client advertises the `fs.writeTextFile` capability.
@@ -220,6 +254,19 @@ export class ClientSideConnection implements Agent {
             schema.sessionNotificationSchema.parse(params);
           return client.sessionUpdate(
             validatedParams as schema.SessionNotification,
+          );
+        }
+        case schema.CLIENT_METHODS.terminal_new: {
+          const validatedParams = schema.newTerminalRequestSchema.parse(params);
+          return client.newTerminal(
+            validatedParams as schema.NewTerminalRequest,
+          );
+        }
+        case schema.CLIENT_METHODS.terminal_output: {
+          const validatedParams =
+            schema.terminalOutputRequestSchema.parse(params);
+          return client.terminalOutput(
+            validatedParams as schema.TerminalOutputRequest,
           );
         }
         default:
@@ -702,6 +749,28 @@ export interface Client {
   readTextFile(
     params: schema.ReadTextFileRequest,
   ): Promise<schema.ReadTextFileResponse>;
+  /**
+   * Creates a new terminal instance in the client's environment.
+   *
+   * Only available if the client advertises the `terminal` capability.
+   * Allows the agent to spawn and interact with terminal processes.
+   *
+   * See protocol docs: [Client](https://agentclientprotocol.com/protocol/overview#client)
+   */
+  newTerminal(
+    params: schema.NewTerminalRequest,
+  ): Promise<schema.NewTerminalResponse>;
+  /**
+   * Retrieves output from a previously created terminal.
+   *
+   * Only available if the client advertises the `terminal` capability.
+   * Returns the terminal's output buffer and exit status if available.
+   *
+   * See protocol docs: [Client](https://agentclientprotocol.com/protocol/overview#client)
+   */
+  terminalOutput(
+    params: schema.TerminalOutputRequest,
+  ): Promise<schema.TerminalOutputResponse>;
 }
 
 /**

--- a/typescript/schema.ts
+++ b/typescript/schema.ts
@@ -12,7 +12,7 @@ export const CLIENT_METHODS = {
   fs_write_text_file: "fs/write_text_file",
   session_request_permission: "session/request_permission",
   session_update: "session/update",
-  terminal_new: "terminal/new",
+  terminal_create: "terminal/create",
   terminal_output: "terminal/output",
   terminal_release: "terminal/release",
   terminal_wait_for_exit: "terminal/wait_for_exit",
@@ -42,7 +42,7 @@ export type ClientRequest =
   | WriteTextFileRequest
   | ReadTextFileRequest
   | RequestPermissionRequest
-  | NewTerminalRequest
+  | CreateTerminalRequest
   | TerminalOutputRequest
   | ReleaseTerminalRequest
   | WaitForTerminalExitRequest;
@@ -194,7 +194,7 @@ export type ClientResponse =
   | WriteTextFileResponse
   | ReadTextFileResponse
   | RequestPermissionResponse
-  | NewTerminalResponse
+  | CreateTerminalResponse
   | TerminalOutputResponse
   | ReleaseTerminalResponse
   | WaitForTerminalExitResponse;
@@ -463,7 +463,7 @@ export interface ToolCallLocation {
    */
   path: string;
 }
-export interface NewTerminalRequest {
+export interface CreateTerminalRequest {
   args?: string[];
   command: string;
   cwd?: string | null;
@@ -521,7 +521,7 @@ export interface RequestPermissionResponse {
         outcome: "selected";
       };
 }
-export interface NewTerminalResponse {
+export interface CreateTerminalResponse {
   terminalId: string;
 }
 export interface TerminalOutputResponse {
@@ -1066,7 +1066,7 @@ export const requestPermissionResponseSchema = z.object({
 });
 
 /** @internal */
-export const newTerminalResponseSchema = z.object({
+export const createTerminalResponseSchema = z.object({
   terminalId: z.string(),
 });
 
@@ -1311,7 +1311,7 @@ export const planEntrySchema = z.object({
 export const clientNotificationSchema = cancelNotificationSchema;
 
 /** @internal */
-export const newTerminalRequestSchema = z.object({
+export const createTerminalRequestSchema = z.object({
   args: z.array(z.string()).optional(),
   command: z.string(),
   cwd: z.string().optional().nullable(),
@@ -1432,7 +1432,7 @@ export const clientResponseSchema = z.union([
   writeTextFileResponseSchema,
   readTextFileResponseSchema,
   requestPermissionResponseSchema,
-  newTerminalResponseSchema,
+  createTerminalResponseSchema,
   terminalOutputResponseSchema,
   releaseTerminalResponseSchema,
   waitForTerminalExitResponseSchema,
@@ -1466,7 +1466,7 @@ export const clientRequestSchema = z.union([
   writeTextFileRequestSchema,
   readTextFileRequestSchema,
   requestPermissionRequestSchema,
-  newTerminalRequestSchema,
+  createTerminalRequestSchema,
   terminalOutputRequestSchema,
   releaseTerminalRequestSchema,
   waitForTerminalExitRequestSchema,

--- a/typescript/schema.ts
+++ b/typescript/schema.ts
@@ -581,6 +581,11 @@ export interface InitializeRequest {
  */
 export interface ClientCapabilities {
   fs?: FileSystemCapability;
+  /**
+   * **UNSTABLE**
+   *
+   * This capability is not part of the spec yet, and may be removed or changed at any point.
+   */
   terminal?: boolean;
 }
 /**


### PR DESCRIPTION
Introduces an experimental `terminal` client capability which allows Agents to create terminals in the Client environment:

- `terminal/create`:  Creates a new terminal with a command and returns a `TerminalId`
- `terminal/output`: Returns the current terminal output without waiting for the process to exit
- `terminal/wait_for_exit`: Waits until the process exits and returns the process exit code and signal
- `terminal/release`: Releases the terminal resource in the client, killing the process if it hasn't exited already

Between `terminal/create` and `terminal/release`, the `TerminalId` can be used to embed the terminal in a ToolCall.

Note: This is not part of the spec yet and should not be depended upon. We'll stabilize it once we have confirmed it works well in a few implementations.

