### PR TITLE
Experimental Command support 

### DIFF
--- a/docs/protocol/schema.mdx
+++ b/docs/protocol/schema.mdx
@@ -92,7 +92,7 @@ See protocol docs: [Initialization](https://agentclientprotocol.com/protocol/ini
 <ResponseField name="agentCapabilities" type={<a href="#agentcapabilities">AgentCapabilities</a>} >
   Capabilities supported by the agent.
 
-    - Default: `{"loadSession":false,"promptCapabilities":{"audio":false,"embeddedContext":false,"image":false}}`
+    - Default: `{"loadSession":false,"promptCapabilities":{"audio":false,"embeddedContext":false,"image":false,"supportsCustomCommands":false}}`
 
 </ResponseField>
 <ResponseField name="authMethods" type={<><span><a href="#authmethod">AuthMethod</a></span><span>[]</span></>} >
@@ -141,6 +141,53 @@ See protocol docs: [Cancellation](https://agentclientprotocol.com/protocol/promp
   required
 >
   The ID of the session to cancel operations for.
+</ResponseField>
+
+<a id="session-list_commands"></a>
+### <span class="font-mono">session/list_commands</span>
+
+Lists available custom commands for a session.
+
+Returns all commands available in the agent's `.claude/commands` directory
+or equivalent command registry. Commands can be executed via `run_command`.
+
+#### <span class="font-mono">ListCommandsRequest</span>
+
+Request parameters for listing available commands.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField
+  name="sessionId"
+  type={<a href="#sessionid">SessionId</a>}
+  required
+>
+  The session ID to list commands for.
+</ResponseField>
+
+#### <span class="font-mono">ListCommandsResponse</span>
+
+Response containing available commands.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField
+  name="commands"
+  type={
+    <>
+      <span>
+        <a href="#commandinfo">CommandInfo</a>
+      </span>
+      <span>[]</span>
+    </>
+  }
+  required
+>
+  List of available commands.
 </ResponseField>
 
 <a id="session-load"></a>
@@ -321,6 +368,36 @@ See protocol docs: [Check for Completion](https://agentclientprotocol.com/protoc
   required
 >
   Indicates why the agent stopped processing the turn.
+</ResponseField>
+
+<a id="session-run_command"></a>
+### <span class="font-mono">session/run_command</span>
+
+Executes a custom command within a session.
+
+Runs the specified command with optional arguments. The agent should
+stream results back via session update notifications.
+
+#### <span class="font-mono">RunCommandRequest</span>
+
+Request parameters for executing a command.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="args" type={"string | null"}>
+  Optional arguments for the command.
+</ResponseField>
+<ResponseField name="command" type={"string"} required>
+  Name of the command to execute.
+</ResponseField>
+<ResponseField
+  name="sessionId"
+  type={<a href="#sessionid">SessionId</a>}
+  required
+>
+  The session ID to execute the command in.
 </ResponseField>
 
 ## Client
@@ -539,7 +616,7 @@ See protocol docs: [Agent Capabilities](https://agentclientprotocol.com/protocol
 <ResponseField name="promptCapabilities" type={<a href="#promptcapabilities">PromptCapabilities</a>} >
   Prompt capabilities supported by the agent.
 
-    - Default: `{"audio":false,"embeddedContext":false,"image":false}`
+    - Default: `{"audio":false,"embeddedContext":false,"image":false,"supportsCustomCommands":false}`
 
 </ResponseField>
 
@@ -644,6 +721,24 @@ This capability is not part of the spec yet, and may be removed or changed at an
 
     - Default: `false`
 
+</ResponseField>
+
+## <span class="font-mono">CommandInfo</span>
+
+Information about a custom command.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="description" type={"string"} required>
+  Human-readable description of what the command does.
+</ResponseField>
+<ResponseField name="name" type={"string"} required>
+  Command name (e.g., "create_plan", "research_codebase").
+</ResponseField>
+<ResponseField name="requiresArgument" type={"boolean"} required>
+  Whether this command requires arguments from the user.
 </ResponseField>
 
 ## <span class="font-mono">ContentBlock</span>
@@ -1148,6 +1243,12 @@ in prompt requests for pieces of context that are referenced in the message.
 </ResponseField>
 <ResponseField name="image" type={"boolean"} >
   Agent supports `ContentBlock::Image`.
+
+    - Default: `false`
+
+</ResponseField>
+<ResponseField name="supportsCustomCommands" type={"boolean"} >
+  Agent supports custom slash commands via `list_commands` and `run_command`.
 
     - Default: `false`
 

--- a/docs/protocol/schema.mdx
+++ b/docs/protocol/schema.mdx
@@ -700,7 +700,7 @@ This capability is not part of the spec yet, and may be removed or changed at an
 
 ## <span class="font-mono">CommandInfo</span>
 
-Information about a custom command.
+Information about a command.
 
 **Type:** Object
 

--- a/docs/protocol/schema.mdx
+++ b/docs/protocol/schema.mdx
@@ -92,7 +92,7 @@ See protocol docs: [Initialization](https://agentclientprotocol.com/protocol/ini
 <ResponseField name="agentCapabilities" type={<a href="#agentcapabilities">AgentCapabilities</a>} >
   Capabilities supported by the agent.
 
-    - Default: `{"loadSession":false,"promptCapabilities":{"audio":false,"embeddedContext":false,"image":false,"supportsCommands":false}}`
+    - Default: `{"loadSession":false,"promptCapabilities":{"audio":false,"embeddedContext":false,"image":false},"supportsCommands":false}`
 
 </ResponseField>
 <ResponseField name="authMethods" type={<><span><a href="#authmethod">AuthMethod</a></span><span>[]</span></>} >
@@ -616,7 +616,13 @@ See protocol docs: [Agent Capabilities](https://agentclientprotocol.com/protocol
 <ResponseField name="promptCapabilities" type={<a href="#promptcapabilities">PromptCapabilities</a>} >
   Prompt capabilities supported by the agent.
 
-    - Default: `{"audio":false,"embeddedContext":false,"image":false,"supportsCommands":false}`
+    - Default: `{"audio":false,"embeddedContext":false,"image":false}`
+
+</ResponseField>
+<ResponseField name="supportsCommands" type={"boolean"} >
+  Agent supports commands via `list_commands` and `run_command`.
+
+    - Default: `false`
 
 </ResponseField>
 
@@ -1243,12 +1249,6 @@ in prompt requests for pieces of context that are referenced in the message.
 </ResponseField>
 <ResponseField name="image" type={"boolean"} >
   Agent supports `ContentBlock::Image`.
-
-    - Default: `false`
-
-</ResponseField>
-<ResponseField name="supportsCommands" type={"boolean"} >
-  Agent supports commands via `list_commands` and `run_command`.
 
     - Default: `false`
 

--- a/docs/protocol/schema.mdx
+++ b/docs/protocol/schema.mdx
@@ -92,7 +92,7 @@ See protocol docs: [Initialization](https://agentclientprotocol.com/protocol/ini
 <ResponseField name="agentCapabilities" type={<a href="#agentcapabilities">AgentCapabilities</a>} >
   Capabilities supported by the agent.
 
-    - Default: `{"loadSession":false,"promptCapabilities":{"audio":false,"embeddedContext":false,"image":false,"supportsCustomCommands":false}}`
+    - Default: `{"loadSession":false,"promptCapabilities":{"audio":false,"embeddedContext":false,"image":false,"supportsCommands":false}}`
 
 </ResponseField>
 <ResponseField name="authMethods" type={<><span><a href="#authmethod">AuthMethod</a></span><span>[]</span></>} >
@@ -616,7 +616,7 @@ See protocol docs: [Agent Capabilities](https://agentclientprotocol.com/protocol
 <ResponseField name="promptCapabilities" type={<a href="#promptcapabilities">PromptCapabilities</a>} >
   Prompt capabilities supported by the agent.
 
-    - Default: `{"audio":false,"embeddedContext":false,"image":false,"supportsCustomCommands":false}`
+    - Default: `{"audio":false,"embeddedContext":false,"image":false,"supportsCommands":false}`
 
 </ResponseField>
 
@@ -1247,8 +1247,8 @@ in prompt requests for pieces of context that are referenced in the message.
     - Default: `false`
 
 </ResponseField>
-<ResponseField name="supportsCustomCommands" type={"boolean"} >
-  Agent supports custom slash commands via `list_commands` and `run_command`.
+<ResponseField name="supportsCommands" type={"boolean"} >
+  Agent supports commands via `list_commands` and `run_command`.
 
     - Default: `false`
 

--- a/docs/protocol/schema.mdx
+++ b/docs/protocol/schema.mdx
@@ -146,10 +146,9 @@ See protocol docs: [Cancellation](https://agentclientprotocol.com/protocol/promp
 <a id="session-list_commands"></a>
 ### <span class="font-mono">session/list_commands</span>
 
-Lists available custom commands for a session.
+**UNSTABLE**
 
-Returns all commands available in the agent's `.claude/commands` directory
-or equivalent command registry. Commands can be executed via `run_command`.
+This method is not part of the spec, and may be removed or changed at any point.
 
 #### <span class="font-mono">ListCommandsRequest</span>
 
@@ -368,36 +367,6 @@ See protocol docs: [Check for Completion](https://agentclientprotocol.com/protoc
   required
 >
   Indicates why the agent stopped processing the turn.
-</ResponseField>
-
-<a id="session-run_command"></a>
-### <span class="font-mono">session/run_command</span>
-
-Executes a custom command within a session.
-
-Runs the specified command with optional arguments. The agent should
-stream results back via session update notifications.
-
-#### <span class="font-mono">RunCommandRequest</span>
-
-Request parameters for executing a command.
-
-**Type:** Object
-
-**Properties:**
-
-<ResponseField name="args" type={"string | null"}>
-  Optional arguments for the command.
-</ResponseField>
-<ResponseField name="command" type={"string"} required>
-  Name of the command to execute.
-</ResponseField>
-<ResponseField
-  name="sessionId"
-  type={<a href="#sessionid">SessionId</a>}
-  required
->
-  The session ID to execute the command in.
 </ResponseField>
 
 ## Client
@@ -620,7 +589,7 @@ See protocol docs: [Agent Capabilities](https://agentclientprotocol.com/protocol
 
 </ResponseField>
 <ResponseField name="supportsCommands" type={"boolean"} >
-  Agent supports commands via `list_commands` and `run_command`.
+  Agent supports commands via `list_commands`.
 
     - Default: `false`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zed-industries/agent-client-protocol",
-  "version": "0.1.3-alpha.0",
+  "version": "0.2.0-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zed-industries/agent-client-protocol",
-      "version": "0.1.3-alpha.0",
+      "version": "0.2.0-alpha.0",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.0.0"

--- a/rust/acp.rs
+++ b/rust/acp.rs
@@ -228,15 +228,6 @@ impl Agent for ClientSideConnection {
             )
             .await
     }
-
-    async fn run_command(&self, arguments: RunCommandRequest) -> Result<(), Error> {
-        self.conn
-            .request(
-                SESSION_RUN_COMMAND,
-                Some(ClientRequest::RunCommandRequest(arguments)),
-            )
-            .await
-    }
 }
 
 /// Marker type representing the client side of an ACP connection.
@@ -533,9 +524,6 @@ impl Side for AgentSide {
             SESSION_LIST_COMMANDS => serde_json::from_str(params.get())
                 .map(ClientRequest::ListCommandsRequest)
                 .map_err(Into::into),
-            SESSION_RUN_COMMAND => serde_json::from_str(params.get())
-                .map(ClientRequest::RunCommandRequest)
-                .map_err(Into::into),
             _ => Err(Error::method_not_found()),
         }
     }
@@ -581,10 +569,6 @@ impl<T: Agent> MessageHandler<AgentSide> for T {
             ClientRequest::ListCommandsRequest(args) => {
                 let response = self.list_commands(args).await?;
                 Ok(AgentResponse::ListCommandsResponse(response))
-            }
-            ClientRequest::RunCommandRequest(args) => {
-                self.run_command(args).await?;
-                Ok(AgentResponse::AuthenticateResponse) // No specific response type for run_command
             }
         }
     }

--- a/rust/agent.rs
+++ b/rust/agent.rs
@@ -402,7 +402,7 @@ pub struct ListCommandsResponse {
     pub commands: Vec<CommandInfo>,
 }
 
-/// Information about a custom command.
+/// Information about a command.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CommandInfo {

--- a/rust/agent.rs
+++ b/rust/agent.rs
@@ -383,9 +383,9 @@ pub struct PromptCapabilities {
     /// in prompt requests for pieces of context that are referenced in the message.
     #[serde(default)]
     pub embedded_context: bool,
-    /// Agent supports custom slash commands via `list_commands` and `run_command`.
+    /// Agent supports commands via `list_commands` and `run_command`.
     #[serde(default)]
-    pub supports_custom_commands: bool,
+    pub supports_commands: bool,
 }
 
 // Slash commands
@@ -452,6 +452,10 @@ pub struct AgentMethodNames {
     pub session_prompt: &'static str,
     /// Notification for cancelling operations.
     pub session_cancel: &'static str,
+    /// Method for listing available commands.
+    pub session_list_commands: &'static str,
+    /// Method for running a command.
+    pub session_run_command: &'static str,
 }
 
 /// Constant containing all agent method names.
@@ -462,6 +466,8 @@ pub const AGENT_METHOD_NAMES: AgentMethodNames = AgentMethodNames {
     session_load: SESSION_LOAD_METHOD_NAME,
     session_prompt: SESSION_PROMPT_METHOD_NAME,
     session_cancel: SESSION_CANCEL_METHOD_NAME,
+    session_list_commands: SESSION_LIST_COMMANDS,
+    session_run_command: SESSION_RUN_COMMAND,
 };
 
 /// Method name for the initialize request.
@@ -478,7 +484,7 @@ pub(crate) const SESSION_PROMPT_METHOD_NAME: &str = "session/prompt";
 pub(crate) const SESSION_CANCEL_METHOD_NAME: &str = "session/cancel";
 /// Method name for listing custom commands in a session.
 pub const SESSION_LIST_COMMANDS: &str = "session/list_commands";
-/// Method name for running a custom command in a session.  
+/// Method name for running a custom command in a session.
 pub const SESSION_RUN_COMMAND: &str = "session/run_command";
 
 /// All possible requests that a client can send to an agent.

--- a/rust/agent.rs
+++ b/rust/agent.rs
@@ -354,6 +354,10 @@ pub struct AgentCapabilities {
     /// Prompt capabilities supported by the agent.
     #[serde(default)]
     pub prompt_capabilities: PromptCapabilities,
+
+    /// Agent supports commands via `list_commands` and `run_command`.
+    #[serde(default)]
+    pub supports_commands: bool,
 }
 
 /// Prompt capabilities supported by the agent in `session/prompt` requests.
@@ -383,9 +387,6 @@ pub struct PromptCapabilities {
     /// in prompt requests for pieces of context that are referenced in the message.
     #[serde(default)]
     pub embedded_context: bool,
-    /// Agent supports commands via `list_commands` and `run_command`.
-    #[serde(default)]
-    pub supports_commands: bool,
 }
 
 // Slash commands

--- a/rust/example_agent.rs
+++ b/rust/example_agent.rs
@@ -110,11 +110,6 @@ impl acp::Agent for ExampleAgent {
             }],
         })
     }
-
-    async fn run_command(&self, arguments: acp::RunCommandRequest) -> Result<(), acp::Error> {
-        log::info!("Received run_command request {arguments:?}");
-        Ok(())
-    }
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/rust/example_agent.rs
+++ b/rust/example_agent.rs
@@ -96,6 +96,25 @@ impl acp::Agent for ExampleAgent {
         log::info!("Received cancel request {args:?}");
         Ok(())
     }
+
+    async fn list_commands(
+        &self,
+        arguments: acp::ListCommandsRequest,
+    ) -> Result<acp::ListCommandsResponse, acp::Error> {
+        log::info!("Received list_commands request {arguments:?}");
+        Ok(acp::ListCommandsResponse {
+            commands: vec![acp::CommandInfo {
+                name: "test".to_string(),
+                description: "A test command".to_string(),
+                requires_argument: false,
+            }],
+        })
+    }
+
+    async fn run_command(&self, arguments: acp::RunCommandRequest) -> Result<(), acp::Error> {
+        log::info!("Received run_command request {arguments:?}");
+        Ok(())
+    }
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/rust/markdown_generator.rs
+++ b/rust/markdown_generator.rs
@@ -634,6 +634,8 @@ impl SideDocs {
             "session/load" => self.agent_methods.get("load_session").unwrap(),
             "session/prompt" => self.agent_methods.get("prompt").unwrap(),
             "session/cancel" => self.agent_methods.get("cancel").unwrap(),
+            "session/list_commands" => self.agent_methods.get("list_commands").unwrap(),
+            "session/run_command" => self.agent_methods.get("run_command").unwrap(),
             _ => panic!("Introduced a method? Add it here :)"),
         }
     }

--- a/rust/markdown_generator.rs
+++ b/rust/markdown_generator.rs
@@ -635,7 +635,6 @@ impl SideDocs {
             "session/prompt" => self.agent_methods.get("prompt").unwrap(),
             "session/cancel" => self.agent_methods.get("cancel").unwrap(),
             "session/list_commands" => self.agent_methods.get("list_commands").unwrap(),
-            "session/run_command" => self.agent_methods.get("run_command").unwrap(),
             _ => panic!("Introduced a method? Add it here :)"),
         }
     }

--- a/rust/rpc_tests.rs
+++ b/rust/rpc_tests.rs
@@ -167,10 +167,6 @@ impl Agent for TestAgent {
     ) -> Result<ListCommandsResponse, Error> {
         Ok(ListCommandsResponse { commands: vec![] })
     }
-
-    async fn run_command(&self, _arguments: RunCommandRequest) -> Result<(), Error> {
-        Ok(())
-    }
 }
 
 // Helper function to create a bidirectional connection

--- a/rust/rpc_tests.rs
+++ b/rust/rpc_tests.rs
@@ -160,6 +160,17 @@ impl Agent for TestAgent {
             .push(args.session_id);
         Ok(())
     }
+
+    async fn list_commands(
+        &self,
+        _arguments: ListCommandsRequest,
+    ) -> Result<ListCommandsResponse, Error> {
+        Ok(ListCommandsResponse { commands: vec![] })
+    }
+
+    async fn run_command(&self, _arguments: RunCommandRequest) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 // Helper function to create a bidirectional connection

--- a/schema/meta.json
+++ b/schema/meta.json
@@ -3,9 +3,11 @@
     "authenticate": "authenticate",
     "initialize": "initialize",
     "session_cancel": "session/cancel",
+    "session_list_commands": "session/list_commands",
     "session_load": "session/load",
     "session_new": "session/new",
-    "session_prompt": "session/prompt"
+    "session_prompt": "session/prompt",
+    "session_run_command": "session/run_command"
   },
   "clientMethods": {
     "fs_read_text_file": "fs/read_text_file",

--- a/schema/meta.json
+++ b/schema/meta.json
@@ -6,8 +6,7 @@
     "session_list_commands": "session/list_commands",
     "session_load": "session/load",
     "session_new": "session/new",
-    "session_prompt": "session/prompt",
-    "session_run_command": "session/run_command"
+    "session_prompt": "session/prompt"
   },
   "clientMethods": {
     "fs_read_text_file": "fs/read_text_file",

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -300,7 +300,7 @@
       "x-docs-ignore": true
     },
     "CommandInfo": {
-      "description": "Information about a custom command.",
+      "description": "Information about a command.",
       "properties": {
         "description": {
           "description": "Human-readable description of what the command does.",

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -19,7 +19,7 @@
         },
         "supportsCommands": {
           "default": false,
-          "description": "Agent supports commands via `list_commands` and `run_command`.",
+          "description": "Agent supports commands via `list_commands`.",
           "type": "boolean"
         }
       },
@@ -260,10 +260,6 @@
         {
           "$ref": "#/$defs/ListCommandsRequest",
           "title": "ListCommandsRequest"
-        },
-        {
-          "$ref": "#/$defs/RunCommandRequest",
-          "title": "RunCommandRequest"
         }
       ],
       "description": "All possible requests that a client can send to an agent.\n\nThis enum is used internally for routing RPC requests. You typically won't need\nto use this directly - instead, use the methods on the [`Agent`] trait.\n\nThis enum encompasses all method calls from client to agent.",
@@ -1120,27 +1116,6 @@
       "description": "The sender or recipient of messages and data in a conversation.",
       "enum": ["assistant", "user"],
       "type": "string"
-    },
-    "RunCommandRequest": {
-      "description": "Request parameters for executing a command.",
-      "properties": {
-        "args": {
-          "description": "Optional arguments for the command.",
-          "type": ["string", "null"]
-        },
-        "command": {
-          "description": "Name of the command to execute.",
-          "type": "string"
-        },
-        "sessionId": {
-          "$ref": "#/$defs/SessionId",
-          "description": "The session ID to execute the command in."
-        }
-      },
-      "required": ["sessionId", "command"],
-      "type": "object",
-      "x-method": "session/run_command",
-      "x-side": "agent"
     },
     "SessionId": {
       "description": "A unique identifier for a conversation session between a client and agent.\n\nSessions maintain their own context, conversation history, and state,\nallowing multiple independent interactions with the same agent.\n\n# Example\n\n```\nuse agent_client_protocol::SessionId;\nuse std::sync::Arc;\n\nlet session_id = SessionId(Arc::from(\"sess_abc123def456\"));\n```\n\nSee protocol docs: [Session ID](https://agentclientprotocol.com/protocol/session-setup#session-id)",

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -14,7 +14,7 @@
             "audio": false,
             "embeddedContext": false,
             "image": false,
-            "supportsCustomCommands": false
+            "supportsCommands": false
           },
           "description": "Prompt capabilities supported by the agent."
         }
@@ -636,7 +636,7 @@
               "audio": false,
               "embeddedContext": false,
               "image": false,
-              "supportsCustomCommands": false
+              "supportsCommands": false
             }
           },
           "description": "Capabilities supported by the agent."
@@ -913,9 +913,9 @@
           "description": "Agent supports [`ContentBlock::Image`].",
           "type": "boolean"
         },
-        "supportsCustomCommands": {
+        "supportsCommands": {
           "default": false,
-          "description": "Agent supports custom slash commands via `list_commands` and `run_command`.",
+          "description": "Agent supports commands via `list_commands` and `run_command`.",
           "type": "boolean"
         }
       },

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -13,10 +13,14 @@
           "default": {
             "audio": false,
             "embeddedContext": false,
-            "image": false,
-            "supportsCommands": false
+            "image": false
           },
           "description": "Prompt capabilities supported by the agent."
+        },
+        "supportsCommands": {
+          "default": false,
+          "description": "Agent supports commands via `list_commands` and `run_command`.",
+          "type": "boolean"
         }
       },
       "type": "object"
@@ -635,9 +639,9 @@
             "promptCapabilities": {
               "audio": false,
               "embeddedContext": false,
-              "image": false,
-              "supportsCommands": false
-            }
+              "image": false
+            },
+            "supportsCommands": false
           },
           "description": "Capabilities supported by the agent."
         },
@@ -911,11 +915,6 @@
         "image": {
           "default": false,
           "description": "Agent supports [`ContentBlock::Image`].",
-          "type": "boolean"
-        },
-        "supportsCommands": {
-          "default": false,
-          "description": "Agent supports commands via `list_commands` and `run_command`.",
           "type": "boolean"
         }
       },

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -13,7 +13,8 @@
           "default": {
             "audio": false,
             "embeddedContext": false,
-            "image": false
+            "image": false,
+            "supportsCustomCommands": false
           },
           "description": "Prompt capabilities supported by the agent."
         }
@@ -85,6 +86,10 @@
         {
           "$ref": "#/$defs/PromptResponse",
           "title": "PromptResponse"
+        },
+        {
+          "$ref": "#/$defs/ListCommandsResponse",
+          "title": "ListCommandsResponse"
         }
       ],
       "description": "All possible responses that an agent can send to a client.\n\nThis enum is used internally for routing RPC responses. You typically won't need\nto use this directly - the responses are handled automatically by the connection.\n\nThese are responses to the corresponding ClientRequest variants.",
@@ -247,6 +252,14 @@
         {
           "$ref": "#/$defs/PromptRequest",
           "title": "PromptRequest"
+        },
+        {
+          "$ref": "#/$defs/ListCommandsRequest",
+          "title": "ListCommandsRequest"
+        },
+        {
+          "$ref": "#/$defs/RunCommandRequest",
+          "title": "RunCommandRequest"
         }
       ],
       "description": "All possible requests that a client can send to an agent.\n\nThis enum is used internally for routing RPC requests. You typically won't need\nto use this directly - instead, use the methods on the [`Agent`] trait.\n\nThis enum encompasses all method calls from client to agent.",
@@ -285,6 +298,25 @@
       ],
       "description": "All possible responses that a client can send to an agent.\n\nThis enum is used internally for routing RPC responses. You typically won't need\nto use this directly - the responses are handled automatically by the connection.\n\nThese are responses to the corresponding AgentRequest variants.",
       "x-docs-ignore": true
+    },
+    "CommandInfo": {
+      "description": "Information about a custom command.",
+      "properties": {
+        "description": {
+          "description": "Human-readable description of what the command does.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Command name (e.g., \"create_plan\", \"research_codebase\").",
+          "type": "string"
+        },
+        "requiresArgument": {
+          "description": "Whether this command requires arguments from the user.",
+          "type": "boolean"
+        }
+      },
+      "required": ["name", "description", "requiresArgument"],
+      "type": "object"
     },
     "ContentBlock": {
       "description": "Content blocks represent displayable information in the Agent Client Protocol.\n\nThey provide a structured way to handle various types of user-facing content—whether\nit's text from language models, images for analysis, or embedded resources for context.\n\nContent blocks appear in:\n- User prompts sent via `session/prompt`\n- Language model output streamed through `session/update` notifications\n- Progress updates and results from tool calls\n\nThis structure is compatible with the Model Context Protocol (MCP), enabling\nagents to seamlessly forward content from MCP tool outputs without transformation.\n\nSee protocol docs: [Content](https://agentclientprotocol.com/protocol/content)",
@@ -603,7 +635,8 @@
             "promptCapabilities": {
               "audio": false,
               "embeddedContext": false,
-              "image": false
+              "image": false,
+              "supportsCustomCommands": false
             }
           },
           "description": "Capabilities supported by the agent."
@@ -624,6 +657,35 @@
       "required": ["protocolVersion"],
       "type": "object",
       "x-method": "initialize",
+      "x-side": "agent"
+    },
+    "ListCommandsRequest": {
+      "description": "Request parameters for listing available commands.",
+      "properties": {
+        "sessionId": {
+          "$ref": "#/$defs/SessionId",
+          "description": "The session ID to list commands for."
+        }
+      },
+      "required": ["sessionId"],
+      "type": "object",
+      "x-method": "session/list_commands",
+      "x-side": "agent"
+    },
+    "ListCommandsResponse": {
+      "description": "Response containing available commands.",
+      "properties": {
+        "commands": {
+          "description": "List of available commands.",
+          "items": {
+            "$ref": "#/$defs/CommandInfo"
+          },
+          "type": "array"
+        }
+      },
+      "required": ["commands"],
+      "type": "object",
+      "x-method": "session/list_commands",
       "x-side": "agent"
     },
     "LoadSessionRequest": {
@@ -850,6 +912,11 @@
           "default": false,
           "description": "Agent supports [`ContentBlock::Image`].",
           "type": "boolean"
+        },
+        "supportsCustomCommands": {
+          "default": false,
+          "description": "Agent supports custom slash commands via `list_commands` and `run_command`.",
+          "type": "boolean"
         }
       },
       "type": "object"
@@ -1054,6 +1121,27 @@
       "description": "The sender or recipient of messages and data in a conversation.",
       "enum": ["assistant", "user"],
       "type": "string"
+    },
+    "RunCommandRequest": {
+      "description": "Request parameters for executing a command.",
+      "properties": {
+        "args": {
+          "description": "Optional arguments for the command.",
+          "type": ["string", "null"]
+        },
+        "command": {
+          "description": "Name of the command to execute.",
+          "type": "string"
+        },
+        "sessionId": {
+          "$ref": "#/$defs/SessionId",
+          "description": "The session ID to execute the command in."
+        }
+      },
+      "required": ["sessionId", "command"],
+      "type": "object",
+      "x-method": "session/run_command",
+      "x-side": "agent"
     },
     "SessionId": {
       "description": "A unique identifier for a conversation session between a client and agent.\n\nSessions maintain their own context, conversation history, and state,\nallowing multiple independent interactions with the same agent.\n\n# Example\n\n```\nuse agent_client_protocol::SessionId;\nuse std::sync::Arc;\n\nlet session_id = SessionId(Arc::from(\"sess_abc123def456\"));\n```\n\nSee protocol docs: [Session ID](https://agentclientprotocol.com/protocol/session-setup#session-id)",

--- a/typescript/acp.test.ts
+++ b/typescript/acp.test.ts
@@ -24,6 +24,9 @@ import {
   CancelNotification,
   SessionNotification,
   PROTOCOL_VERSION,
+  ListCommandsRequest,
+  ListCommandsResponse,
+  RunCommandRequest,
 } from "./acp.js";
 
 describe("Connection", () => {
@@ -77,6 +80,14 @@ describe("Connection", () => {
       }
       async cancel(_: CancelNotification): Promise<void> {
         // no-op
+      }
+      async listCommands(
+        _: ListCommandsRequest,
+      ): Promise<ListCommandsResponse> {
+        throw new Error("not implemented");
+      }
+      async runCommand(_: RunCommandRequest): Promise<void> {
+        throw new Error("not implemented");
       }
     }
 
@@ -169,6 +180,14 @@ describe("Connection", () => {
       }
       async cancel(_: CancelNotification): Promise<void> {
         // no-op
+      }
+      async listCommands(
+        _: ListCommandsRequest,
+      ): Promise<ListCommandsResponse> {
+        throw new Error("not implemented");
+      }
+      async runCommand(_: RunCommandRequest): Promise<void> {
+        throw new Error("not implemented");
       }
     }
 
@@ -275,6 +294,14 @@ describe("Connection", () => {
       }
       async cancel(params: CancelNotification): Promise<void> {
         messageLog.push(`cancelled called: ${params.sessionId}`);
+      }
+      async listCommands(
+        _: ListCommandsRequest,
+      ): Promise<ListCommandsResponse> {
+        throw new Error("not implemented");
+      }
+      async runCommand(_: RunCommandRequest): Promise<void> {
+        throw new Error("not implemented");
       }
     }
 
@@ -407,6 +434,14 @@ describe("Connection", () => {
       async cancel(params: CancelNotification): Promise<void> {
         notificationLog.push(`cancelled: ${params.sessionId}`);
       }
+      async listCommands(
+        _: ListCommandsRequest,
+      ): Promise<ListCommandsResponse> {
+        throw new Error("not implemented");
+      }
+      async runCommand(_: RunCommandRequest): Promise<void> {
+        throw new Error("not implemented");
+      }
     }
 
     // Create shared instances
@@ -505,6 +540,14 @@ describe("Connection", () => {
       }
       async cancel(_: CancelNotification): Promise<void> {
         // no-op
+      }
+      async listCommands(
+        _: ListCommandsRequest,
+      ): Promise<ListCommandsResponse> {
+        throw new Error("not implemented");
+      }
+      async runCommand(_: RunCommandRequest): Promise<void> {
+        throw new Error("not implemented");
       }
     }
 

--- a/typescript/acp.test.ts
+++ b/typescript/acp.test.ts
@@ -26,7 +26,6 @@ import {
   PROTOCOL_VERSION,
   ListCommandsRequest,
   ListCommandsResponse,
-  RunCommandRequest,
 } from "./acp.js";
 
 describe("Connection", () => {
@@ -84,9 +83,6 @@ describe("Connection", () => {
       async listCommands(
         _: ListCommandsRequest,
       ): Promise<ListCommandsResponse> {
-        throw new Error("not implemented");
-      }
-      async runCommand(_: RunCommandRequest): Promise<void> {
         throw new Error("not implemented");
       }
     }
@@ -184,9 +180,6 @@ describe("Connection", () => {
       async listCommands(
         _: ListCommandsRequest,
       ): Promise<ListCommandsResponse> {
-        throw new Error("not implemented");
-      }
-      async runCommand(_: RunCommandRequest): Promise<void> {
         throw new Error("not implemented");
       }
     }
@@ -298,9 +291,6 @@ describe("Connection", () => {
       async listCommands(
         _: ListCommandsRequest,
       ): Promise<ListCommandsResponse> {
-        throw new Error("not implemented");
-      }
-      async runCommand(_: RunCommandRequest): Promise<void> {
         throw new Error("not implemented");
       }
     }
@@ -439,9 +429,6 @@ describe("Connection", () => {
       ): Promise<ListCommandsResponse> {
         throw new Error("not implemented");
       }
-      async runCommand(_: RunCommandRequest): Promise<void> {
-        throw new Error("not implemented");
-      }
     }
 
     // Create shared instances
@@ -544,9 +531,6 @@ describe("Connection", () => {
       async listCommands(
         _: ListCommandsRequest,
       ): Promise<ListCommandsResponse> {
-        throw new Error("not implemented");
-      }
-      async runCommand(_: RunCommandRequest): Promise<void> {
         throw new Error("not implemented");
       }
     }

--- a/typescript/acp.ts
+++ b/typescript/acp.ts
@@ -73,6 +73,13 @@ export class AgentSideConnection {
           const validatedParams = schema.cancelNotificationSchema.parse(params);
           return agent.cancel(validatedParams as schema.CancelNotification);
         }
+        case schema.AGENT_METHODS.session_list_commands: {
+          const validatedParams =
+            schema.listCommandsRequestSchema.parse(params);
+          return agent.listCommands(
+            validatedParams as schema.ListCommandsRequest,
+          );
+        }
         default:
           throw RequestError.methodNotFound(method);
       }

--- a/typescript/acp.ts
+++ b/typescript/acp.ts
@@ -446,6 +446,24 @@ export class ClientSideConnection implements Agent {
       params,
     );
   }
+
+  // todo!()
+  async listCommands(
+    params: schema.ListCommandsRequest,
+  ): Promise<schema.ListCommandsResponse> {
+    return await this.#connection.sendRequest(
+      schema.AGENT_METHODS.session_list_commands,
+      params,
+    );
+  }
+
+  // todo!()
+  async runCommand(params: schema.RunCommandRequest): Promise<void> {
+    return await this.#connection.sendRequest(
+      schema.AGENT_METHODS.session_run_command,
+      params,
+    );
+  }
 }
 
 type AnyMessage = AnyRequest | AnyResponse | AnyNotification;
@@ -814,7 +832,7 @@ export interface Client {
    */
   createTerminal?(
     params: schema.CreateTerminalRequest,
-  ): Promise<schema.CreateTerminalResponse>;
+  ): Promise<TerminalHandle>;
 
   /**
    *  @internal **UNSTABLE**
@@ -934,4 +952,10 @@ export interface Agent {
    * See protocol docs: [Cancellation](https://agentclientprotocol.com/protocol/prompt-turn#cancellation)
    */
   cancel(params: schema.CancelNotification): Promise<void>;
+
+  listCommands(
+    params: schema.ListCommandsRequest,
+  ): Promise<schema.ListCommandsResponse>;
+
+  runCommand(params: schema.RunCommandRequest): Promise<void>;
 }

--- a/typescript/acp.ts
+++ b/typescript/acp.ts
@@ -454,20 +454,16 @@ export class ClientSideConnection implements Agent {
     );
   }
 
-  // todo!()
+  /**
+   *  @internal **UNSTABLE**
+   *
+   * This method is not part of the spec, and may be removed or changed at any point.
+   */
   async listCommands(
     params: schema.ListCommandsRequest,
   ): Promise<schema.ListCommandsResponse> {
     return await this.#connection.sendRequest(
       schema.AGENT_METHODS.session_list_commands,
-      params,
-    );
-  }
-
-  // todo!()
-  async runCommand(params: schema.RunCommandRequest): Promise<void> {
-    return await this.#connection.sendRequest(
-      schema.AGENT_METHODS.session_run_command,
       params,
     );
   }
@@ -963,6 +959,4 @@ export interface Agent {
   listCommands(
     params: schema.ListCommandsRequest,
   ): Promise<schema.ListCommandsResponse>;
-
-  runCommand(params: schema.RunCommandRequest): Promise<void>;
 }

--- a/typescript/schema.ts
+++ b/typescript/schema.ts
@@ -2,9 +2,11 @@ export const AGENT_METHODS = {
   authenticate: "authenticate",
   initialize: "initialize",
   session_cancel: "session/cancel",
+  session_list_commands: "session/list_commands",
   session_load: "session/load",
   session_new: "session/new",
   session_prompt: "session/prompt",
+  session_run_command: "session/run_command",
 };
 
 export const CLIENT_METHODS = {
@@ -841,9 +843,9 @@ export interface PromptCapabilities {
    */
   image?: boolean;
   /**
-   * Agent supports custom slash commands via `list_commands` and `run_command`.
+   * Agent supports commands via `list_commands` and `run_command`.
    */
-  supportsCustomCommands?: boolean;
+  supportsCommands?: boolean;
 }
 /**
  * Describes an available authentication method.
@@ -1398,7 +1400,7 @@ export const promptCapabilitiesSchema = z.object({
   audio: z.boolean().optional(),
   embeddedContext: z.boolean().optional(),
   image: z.boolean().optional(),
-  supportsCustomCommands: z.boolean().optional(),
+  supportsCommands: z.boolean().optional(),
 });
 
 /** @internal */

--- a/typescript/schema.ts
+++ b/typescript/schema.ts
@@ -882,7 +882,7 @@ export interface ListCommandsResponse {
   commands: CommandInfo[];
 }
 /**
- * Information about a custom command.
+ * Information about a command.
  */
 export interface CommandInfo {
   /**

--- a/typescript/schema.ts
+++ b/typescript/schema.ts
@@ -822,6 +822,10 @@ export interface AgentCapabilities {
    */
   loadSession?: boolean;
   promptCapabilities?: PromptCapabilities;
+  /**
+   * Agent supports commands via `list_commands` and `run_command`.
+   */
+  supportsCommands?: boolean;
 }
 /**
  * Prompt capabilities supported by the agent.
@@ -842,10 +846,6 @@ export interface PromptCapabilities {
    * Agent supports [`ContentBlock::Image`].
    */
   image?: boolean;
-  /**
-   * Agent supports commands via `list_commands` and `run_command`.
-   */
-  supportsCommands?: boolean;
 }
 /**
  * Describes an available authentication method.
@@ -1400,7 +1400,6 @@ export const promptCapabilitiesSchema = z.object({
   audio: z.boolean().optional(),
   embeddedContext: z.boolean().optional(),
   image: z.boolean().optional(),
-  supportsCommands: z.boolean().optional(),
 });
 
 /** @internal */
@@ -1544,6 +1543,7 @@ export const clientCapabilitiesSchema = z.object({
 export const agentCapabilitiesSchema = z.object({
   loadSession: z.boolean().optional(),
   promptCapabilities: promptCapabilitiesSchema.optional(),
+  supportsCommands: z.boolean().optional(),
 });
 
 /** @internal */

--- a/typescript/schema.ts
+++ b/typescript/schema.ts
@@ -6,7 +6,6 @@ export const AGENT_METHODS = {
   session_load: "session/load",
   session_new: "session/new",
   session_prompt: "session/prompt",
-  session_run_command: "session/run_command",
 };
 
 export const CLIENT_METHODS = {
@@ -227,8 +226,7 @@ export type AgentRequest =
   | NewSessionRequest
   | LoadSessionRequest
   | PromptRequest
-  | ListCommandsRequest
-  | RunCommandRequest;
+  | ListCommandsRequest;
 /**
  * Content blocks represent displayable information in the Agent Client Protocol.
  *
@@ -762,37 +760,6 @@ export interface ListCommandsRequest {
   sessionId: string;
 }
 /**
- * Request parameters for executing a command.
- */
-export interface RunCommandRequest {
-  /**
-   * Optional arguments for the command.
-   */
-  args?: string | null;
-  /**
-   * Name of the command to execute.
-   */
-  command: string;
-  /**
-   * A unique identifier for a conversation session between a client and agent.
-   *
-   * Sessions maintain their own context, conversation history, and state,
-   * allowing multiple independent interactions with the same agent.
-   *
-   * # Example
-   *
-   * ```
-   * use agent_client_protocol::SessionId;
-   * use std::sync::Arc;
-   *
-   * let session_id = SessionId(Arc::from("sess_abc123def456"));
-   * ```
-   *
-   * See protocol docs: [Session ID](https://agentclientprotocol.com/protocol/session-setup#session-id)
-   */
-  sessionId: string;
-}
-/**
  * Response from the initialize method.
  *
  * Contains the negotiated protocol version and agent capabilities.
@@ -823,7 +790,7 @@ export interface AgentCapabilities {
   loadSession?: boolean;
   promptCapabilities?: PromptCapabilities;
   /**
-   * Agent supports commands via `list_commands` and `run_command`.
+   * Agent supports commands via `list_commands`.
    */
   supportsCommands?: boolean;
 }
@@ -1185,13 +1152,6 @@ export const authenticateRequestSchema = z.object({
 
 /** @internal */
 export const listCommandsRequestSchema = z.object({
-  sessionId: z.string(),
-});
-
-/** @internal */
-export const runCommandRequestSchema = z.object({
-  args: z.string().optional().nullable(),
-  command: z.string(),
   sessionId: z.string(),
 });
 
@@ -1599,7 +1559,6 @@ export const agentRequestSchema = z.union([
   loadSessionRequestSchema,
   promptRequestSchema,
   listCommandsRequestSchema,
-  runCommandRequestSchema,
 ]);
 
 /** @internal */


### PR DESCRIPTION
## Summary
- Adds `session/list_commands` method to retrieve available custom commands
- Adds `CommandInfo` type and `supportsCommands` capability
- Updates schema documentation and generated bindings

## Test plan
- [x] Verify schema generation produces correct TypeScript and JSON
- [x] Test example agent compiles and runs with new methods
- [x] Validate protocol documentation renders correctly

🤖 Generated with [Claude Code](https://claude.ai/code)