### PR TITLE
jsonrpc: Specify mandatory `jsonrpc` Version Property

### DIFF
--- a/rust/rpc.rs
+++ b/rust/rpc.rs
@@ -190,7 +190,7 @@ where
                                                 result: ResponseResult::Error(err),
                                             };
 
-                                            serde_json::to_writer(&mut outgoing_line, &error_response)?;
+                                            serde_json::to_writer(&mut outgoing_line, &JsonRpcMessage::wrap(&error_response))?;
                                             log::trace!("send: {}", String::from_utf8_lossy(&outgoing_line));
                                             outgoing_line.push(b'\n');
                                             outgoing_bytes.write_all(&outgoing_line).await.ok();


### PR DESCRIPTION
Closes zed-industries/zed#37128


## Synopsis

[ACP protocol uses 2.0 version of JSON-RPC protocol](https://agentclientprotocol.com/protocol/overview#communication-model), and [JSON-RPC 2.0 Specification requires `"jsonrpc": "2.0"` field to be always present](https://www.jsonrpc.org/specification#compatibility).

## Solution

Provide `rpc::JsonRpcMessage` as a wrapper for `rpc::OutgoingMessage` when sending them.

`rpc::IncomingMessage` are not wrapped on receiving for better compatibility with other parties, which may miss this field.

## Changelog

Release Notes:
- jsonrpc: Fixed missing `"jsonrpc": "2.0"` field
