### PR TITLE
Call toClient directly on ClientSideConnection constructor

### DIFF
--- a/typescript/acp.ts
+++ b/typescript/acp.ts
@@ -262,12 +262,12 @@ export class ClientSideConnection implements Agent {
     input: WritableStream<Uint8Array>,
     output: ReadableStream<Uint8Array>,
   ) {
+    const client = toClient(this);
+
     const handler = async (
       method: string,
       params: unknown,
     ): Promise<unknown> => {
-      const client = toClient(this);
-
       switch (method) {
         case schema.CLIENT_METHODS.fs_write_text_file: {
           const validatedParams =


### PR DESCRIPTION
This fixes an issue we discovered while using the typescript library, where the client would get initialised too late.