### PR TITLE
docs: Add yetone/avante.nvim as supported editors

### DIFF
--- a/docs/overview/introduction.mdx
+++ b/docs/overview/introduction.mdx
@@ -33,6 +33,7 @@ The default format for user-readable text is Markdown, which allows enough flexi
 
 - [Zed](https://zed.dev/docs/ai/external-agents)
 - [neovim](https://neovim.io) through the [CodeCompanion](https://github.com/olimorris/codecompanion.nvim) plugin
+- [yetone/avante.nvim](https://github.com/yetone/avante.nvim): A Neovim plugin designed to emulate the behaviour of the Cursor AI IDE.
 
 ## Supported Agents
 


### PR DESCRIPTION
@yetone's `avante.nvim` is the first editor that implemetned native support for ACP.