### PR TITLE
docs: add python-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Learn more at [agentclientprotocol.com](https://agentclientprotocol.com/).
 
 - **Rust**: [`agent-client-protocol`](https://crates.io/crates/agent-client-protocol) - See [example_agent.rs](./rust/example_agent.rs) and [example_client.rs](./rust/example_client.rs)
 - **TypeScript**: [`@zed-industries/agent-client-protocol`](https://www.npmjs.com/package/@zed-industries/agent-client-protocol) - See [examples/](./typescript/examples/)
+- **Python**: [`agent-client-protocol`](https://pypi.org/project/agent-client-protocol/) - See the [Python SDK repo](https://github.com/psiace/agent-client-protocol-python) and its [Quickstart](https://psiace.github.io/agent-client-protocol-python/quickstart/), maintained by [PsiACE](https://github.com/PsiACE)
 - **JSON Schema**: [schema.json](./schema/schema.json)
 
 ## Contributing

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -62,7 +62,7 @@
       },
       {
         "group": "Libraries",
-        "pages": ["libraries/typescript", "libraries/rust"]
+        "pages": ["libraries/typescript", "libraries/rust", "libraries/python"]
       },
       {
         "group": "Community",

--- a/docs/libraries/python.mdx
+++ b/docs/libraries/python.mdx
@@ -1,0 +1,77 @@
+---
+title: "Python"
+description: "Python library for the Agent Client Protocol"
+---
+
+The [agent-client-protocol](https://pypi.org/project/agent-client-protocol/) Python
+SDK provides implementations of both sides of the Agent Client Protocol that
+you can use to build your own agent server or client.
+
+To get started, add the package as a dependency to your project:
+
+```bash
+pip install agent-client-protocol
+```
+
+Depending on what kind of tool you're building, you'll typically create an
+`AgentSideConnection` (to expose your agent to an ACP-capable client like Zed)
+or a `ClientSideConnection` (to embed an ACP client into your own app).
+
+Minimal agent example:
+
+```python
+import asyncio
+
+from acp import (
+    Agent,
+    AgentSideConnection,
+    AuthenticateRequest,
+    CancelNotification,
+    InitializeRequest,
+    InitializeResponse,
+    LoadSessionRequest,
+    NewSessionRequest,
+    NewSessionResponse,
+    PromptRequest,
+    PromptResponse,
+    stdio_streams,
+)
+
+
+class EchoAgent(Agent):
+    async def initialize(self, params: InitializeRequest) -> InitializeResponse:
+        return InitializeResponse(protocolVersion=params.protocolVersion)
+
+    async def newSession(self, params: NewSessionRequest) -> NewSessionResponse:
+        return NewSessionResponse(sessionId="sess-1")
+
+    async def loadSession(self, params: LoadSessionRequest) -> None:
+        return None
+
+    async def authenticate(self, params: AuthenticateRequest) -> None:
+        return None
+
+    async def prompt(self, params: PromptRequest) -> PromptResponse:
+        # Normally you'd stream updates via sessionUpdate
+        return PromptResponse(stopReason="end_turn")
+
+    async def cancel(self, params: CancelNotification) -> None:
+        return None
+
+
+async def main() -> None:
+    reader, writer = await stdio_streams()
+    # For an agent process, local writes go to client stdin (writer=stdout)
+    AgentSideConnection(lambda _conn: EchoAgent(), writer, reader)
+    # Keep running; in a real agent you would await tasks or add your own loop
+    await asyncio.Event().wait()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+You can run this program from an ACP-capable client such as [Zed](https://zed.dev/docs/ai/external-agents).
+
+- Browse the Python SDK docs and examples: https://github.com/psiace/agent-client-protocol-python
+- Quickstart and a runnable Mini SWE Agent bridge: https://psiace.github.io/agent-client-protocol-python


### PR DESCRIPTION
As a follow-up to #63 

I have implemented a Python SDK for the agent client protocol. 

Additionally, I have implemented two sample clients in repo: 
- the [mini-swe-agent](https://github.com/SWE-agent/mini-swe-agent/) client
- and the echo agent.

Tested on macOS, with zed v0.202.7

<img width="1505" height="953" alt="image" src="https://github.com/user-attachments/assets/2235a15a-d3cc-4279-9042-72e76775826a" />
