### PR TITLE
Support HTTP/SSE in MCP Server configuration types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "futures-util",
  "log",
  "parking_lot",
+ "pretty_assertions",
  "rustyline",
  "schemars",
  "serde",
@@ -197,6 +198,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "dyn-clone"
@@ -576,6 +583,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -1053,3 +1070,9 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,4 @@ futures-util = { version = "0.3", features = ["io"] }
 async-pipe = { git = "https://github.com/zed-industries/async-pipe-rs", rev = "82d00a04211cf4e1236029aa03e6b6ce2a74c553" }
 env_logger = "0.11"
 rustyline = "17.0.1"
+pretty_assertions = "1.4.1"

--- a/docs/protocol/initialization.mdx
+++ b/docs/protocol/initialization.mdx
@@ -141,6 +141,19 @@ Optionally, they **MAY** support richer types of [content](./content) by specify
   The prompt may include `ContentBlock::Resource`
 </ResponseField>
 
+#### MCP capabilities
+
+<ResponseField name="http" type="boolean" post={["default: false"]}>
+  The Agent supports connecting to MCP servers over HTTP.
+</ResponseField>
+
+<ResponseField name="sse" type="boolean" post={["default: false"]}>
+  The Agent supports connecting to MCP servers over SSE.
+
+Note: This transport has been deprecated by the MCP spec.
+
+</ResponseField>
+
 ---
 
 Once the connection is initialized, you're ready to [create a session](./session-setup) and begin the conversation with the Agent.

--- a/docs/protocol/schema.mdx
+++ b/docs/protocol/schema.mdx
@@ -92,7 +92,7 @@ See protocol docs: [Initialization](https://agentclientprotocol.com/protocol/ini
 <ResponseField name="agentCapabilities" type={<a href="#agentcapabilities">AgentCapabilities</a>} >
   Capabilities supported by the agent.
 
-    - Default: `{"loadSession":false,"promptCapabilities":{"audio":false,"embeddedContext":false,"image":false}}`
+    - Default: `{"loadSession":false,"mcpCapabilities":{"http":false,"sse":false},"promptCapabilities":{"audio":false,"embeddedContext":false,"image":false}}`
 
 </ResponseField>
 <ResponseField name="authMethods" type={<><span><a href="#authmethod">AuthMethod</a></span><span>[]</span></>} >
@@ -162,7 +162,7 @@ See protocol docs: [Loading Sessions](https://agentclientprotocol.com/protocol/s
 
 Request parameters for loading an existing session.
 
-Only available if the agent supports the `loadSession` capability.
+Only available if the Agent supports the `loadSession` capability.
 
 See protocol docs: [Loading Sessions](https://agentclientprotocol.com/protocol/session-setup#loading-sessions)
 
@@ -534,6 +534,12 @@ See protocol docs: [Agent Capabilities](https://agentclientprotocol.com/protocol
   Whether the agent supports `session/load`.
 
     - Default: `false`
+
+</ResponseField>
+<ResponseField name="mcpCapabilities" type={<a href="#mcpcapabilities">McpCapabilities</a>} >
+  MCP capabilities supported by the agent.
+
+    - Default: `{"http":false,"sse":false}`
 
 </ResponseField>
 <ResponseField name="promptCapabilities" type={<a href="#promptcapabilities">PromptCapabilities</a>} >
@@ -937,6 +943,21 @@ See protocol docs: [FileSystem](https://agentclientprotocol.com/protocol/initial
 
 </ResponseField>
 
+## <span class="font-mono">HttpHeader</span>
+
+An HTTP header to set when making requests to the MCP server.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="name" type={"string"} required>
+  The name of the HTTP header.
+</ResponseField>
+<ResponseField name="value" type={"string"} required>
+  The value to set for the HTTP header.
+</ResponseField>
+
 ## <span class="font-mono">ImageContent</span>
 
 An image provided to or from an LLM.
@@ -960,6 +981,30 @@ An image provided to or from an LLM.
 <ResponseField name="mimeType" type={"string"} required></ResponseField>
 <ResponseField name="uri" type={"string | null"}></ResponseField>
 
+## <span class="font-mono">McpCapabilities</span>
+
+MCP transport capabilities supported by the agent.
+
+Indicates which MCP server transport mechanisms the agent can use
+to connect to Model Context Protocol servers.
+
+**Type:** Object
+
+**Properties:**
+
+<ResponseField name="http" type={"boolean"} >
+  Agent supports `McpServer::Http`.
+
+    - Default: `false`
+
+</ResponseField>
+<ResponseField name="sse" type={"boolean"} >
+  Agent supports `McpServer::Sse`.
+
+    - Default: `false`
+
+</ResponseField>
+
 ## <span class="font-mono">McpServer</span>
 
 Configuration for connecting to an MCP (Model Context Protocol) server.
@@ -969,9 +1014,78 @@ processing prompts.
 
 See protocol docs: [MCP Servers](https://agentclientprotocol.com/protocol/session-setup#mcp-servers)
 
-**Type:** Object
+**Type:** Union
 
-**Properties:**
+<ResponseField name="http">
+HTTP transport configuration
+
+Only available when the Agent capabilities indicate `mcp_capabilities.http` is `true`.
+
+<Expandable title="Properties">
+
+<ResponseField
+  name="headers"
+  type={
+    <>
+      <span>
+        <a href="#httpheader">HttpHeader</a>
+      </span>
+      <span>[]</span>
+    </>
+  }
+  required
+>
+  HTTP headers to set when making requests to the MCP server.
+</ResponseField>
+<ResponseField name="name" type={"string"} required>
+  Human-readable name identifying this MCP server.
+</ResponseField>
+<ResponseField name="type" type={"string"} required></ResponseField>
+<ResponseField name="url" type={"string"} required>
+  URL to the MCP server.
+</ResponseField>
+
+</Expandable>
+</ResponseField>
+
+<ResponseField name="sse">
+SSE transport configuration
+
+Only available when the Agent capabilities indicate `mcp_capabilities.sse` is `true`.
+
+<Expandable title="Properties">
+
+<ResponseField
+  name="headers"
+  type={
+    <>
+      <span>
+        <a href="#httpheader">HttpHeader</a>
+      </span>
+      <span>[]</span>
+    </>
+  }
+  required
+>
+  HTTP headers to set when making requests to the MCP server.
+</ResponseField>
+<ResponseField name="name" type={"string"} required>
+  Human-readable name identifying this MCP server.
+</ResponseField>
+<ResponseField name="type" type={"string"} required></ResponseField>
+<ResponseField name="url" type={"string"} required>
+  URL to the MCP server.
+</ResponseField>
+
+</Expandable>
+</ResponseField>
+
+<ResponseField name="Object">
+Stdio transport configuration
+
+All Agents MUST support this transport.
+
+<Expandable title="Properties">
 
 <ResponseField
   name="args"
@@ -1004,6 +1118,9 @@ See protocol docs: [MCP Servers](https://agentclientprotocol.com/protocol/sessio
 </ResponseField>
 <ResponseField name="name" type={"string"} required>
   Human-readable name identifying this MCP server.
+</ResponseField>
+
+</Expandable>
 </ResponseField>
 
 ## <span class="font-mono">PermissionOption</span>

--- a/docs/protocol/schema.mdx
+++ b/docs/protocol/schema.mdx
@@ -983,10 +983,7 @@ An image provided to or from an LLM.
 
 ## <span class="font-mono">McpCapabilities</span>
 
-MCP transport capabilities supported by the agent.
-
-Indicates which MCP server transport mechanisms the agent can use
-to connect to Model Context Protocol servers.
+MCP capabilities supported by the agent
 
 **Type:** Object
 

--- a/docs/protocol/session-setup.mdx
+++ b/docs/protocol/session-setup.mdx
@@ -370,6 +370,6 @@ Before using HTTP or SSE transports, Clients **MUST** verify the Agent's capabil
 If `mcpCapabilities.http` is `false` or not present, the Agent does not support HTTP transport.
 If `mcpCapabilities.sse` is `false` or not present, the Agent does not support SSE transport.
 
-Agents **SHOULD** connect to all MCP servers specified by the Client using the appropriate transport mechanism.
+Agents **SHOULD** connect to all MCP servers specified by the Client.
 
 Clients **MAY** use this ability to provide tools directly to the underlying language model by including their own MCP server.

--- a/docs/protocol/session-setup.mdx
+++ b/docs/protocol/session-setup.mdx
@@ -200,7 +200,15 @@ The `cwd` (current working directory) parameter establishes the file system cont
 
 The [Model Context Protocol (MCP)](https://modelcontextprotocol.io) allows Agents to access external tools and data sources. When creating a session, Clients **MAY** include connection details for MCP servers that the Agent should connect to.
 
-Each MCP server specification includes:
+MCP servers can be connected to using different transports. All Agents **MUST** support the stdio transport, while HTTP and SSE transports are optional capabilities that can be checked during initialization.
+
+While they are not required to by the spec, new Agents **SHOULD** support the HTTP transport to ensure compatibility with modern MCP servers.
+
+### Transport Types
+
+#### Stdio Transport
+
+All Agents **MUST** support connecting to MCP servers via stdio (standard input/output). This is the default transport mechanism.
 
 <ParamField path="name" type="string" required>
   A human-readable identifier for the server
@@ -227,6 +235,141 @@ Each MCP server specification includes:
   </Expandable>
 </ParamField>
 
-Agents **SHOULD** connect to all MCP servers specified by the Client.
+Example stdio transport configuration:
+
+```json
+{
+  "name": "filesystem",
+  "command": "/path/to/mcp-server",
+  "args": ["--stdio"],
+  "env": [
+    {
+      "name": "API_KEY",
+      "value": "secret123"
+    }
+  ]
+}
+```
+
+#### HTTP Transport
+
+When the Agent supports `mcpCapabilities.http`, Clients can specify MCP servers configurations using the HTTP transport.
+
+<ParamField path="type" type="string" required>
+  Must be `"http"` to indicate HTTP transport
+</ParamField>
+
+<ParamField path="name" type="string" required>
+  A human-readable identifier for the server
+</ParamField>
+
+<ParamField path="url" type="string" required>
+  The URL of the MCP server
+</ParamField>
+
+<ParamField path="headers" type="HttpHeader[]" required>
+  HTTP headers to include in requests to the server
+
+  <Expandable title="HttpHeader">
+      <ParamField path="name" type="string">
+        The name of the HTTP header.
+      </ParamField>
+      <ParamField path="value" type="string">
+        The value to set for the HTTP header.
+      </ParamField>
+  </Expandable>
+</ParamField>
+
+Example HTTP transport configuration:
+
+```json
+{
+  "type": "http",
+  "name": "api-server",
+  "url": "https://api.example.com/mcp",
+  "headers": [
+    {
+      "name": "Authorization",
+      "value": "Bearer token123"
+    },
+    {
+      "name": "Content-Type",
+      "value": "application/json"
+    }
+  ]
+}
+```
+
+#### SSE Transport
+
+When the Agent supports `mcpCapabilities.sse`, Clients can specify MCP servers configurations using the SSE transport.
+
+<Warning>This transport was deprecated by the MCP spec.</Warning>
+
+<ParamField path="type" type="string" required>
+  Must be `"sse"` to indicate SSE transport
+</ParamField>
+
+<ParamField path="name" type="string" required>
+  A human-readable identifier for the server
+</ParamField>
+
+<ParamField path="url" type="string" required>
+  The URL of the SSE endpoint
+</ParamField>
+
+<ParamField path="headers" type="HttpHeader[]" required>
+  HTTP headers to include when establishing the SSE connection
+
+  <Expandable title="HttpHeader">
+      <ParamField path="name" type="string">
+        The name of the HTTP header.
+      </ParamField>
+      <ParamField path="value" type="string">
+        The value to set for the HTTP header.
+      </ParamField>
+  </Expandable>
+</ParamField>
+
+Example SSE transport configuration:
+
+```json
+{
+  "type": "sse",
+  "name": "event-stream",
+  "url": "https://events.example.com/mcp",
+  "headers": [
+    {
+      "name": "X-API-Key",
+      "value": "apikey456"
+    }
+  ]
+}
+```
+
+### Checking Transport Support
+
+Before using HTTP or SSE transports, Clients **MUST** verify the Agent's capabilities during initialization:
+
+```json highlight={7-10}
+{
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": {
+    "protocolVersion": 1,
+    "agentCapabilities": {
+      "mcpCapabilities": {
+        "http": true,
+        "sse": true
+      }
+    }
+  }
+}
+```
+
+If `mcpCapabilities.http` is `false` or not present, the Agent does not support HTTP transport.
+If `mcpCapabilities.sse` is `false` or not present, the Agent does not support SSE transport.
+
+Agents **SHOULD** connect to all MCP servers specified by the Client using the appropriate transport mechanism.
 
 Clients **MAY** use this ability to provide tools directly to the underlying language model by including their own MCP server.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lint": "cargo clippy",
     "lint:fix": "cargo clippy --fix",
     "check": "npm run lint && npm run format:check && npm run build && npm run test && npm run docs:ts:verify",
-    "docs": "cd docs && npx mint dev",
+    "docs": "cd docs && npx mint@4.2.93 dev",
     "docs:ts:build": "cd typescript && typedoc && echo 'TypeScript documentation generated in ./typescript/docs'",
     "docs:ts:dev": "concurrently \"cd typescript && typedoc --watch --preserveWatchOutput\" \"npx http-server typescript/docs -p 8081\"",
     "docs:ts:verify": "cd typescript && typedoc --emit none && echo 'TypeDoc verification passed'"

--- a/rust/agent.rs
+++ b/rust/agent.rs
@@ -413,10 +413,7 @@ pub struct PromptCapabilities {
     pub embedded_context: bool,
 }
 
-/// MCP transport capabilities supported by the agent.
-///
-/// Indicates which MCP server transport mechanisms the agent can use
-/// to connect to Model Context Protocol servers.
+/// MCP capabilities supported by the agent
 #[derive(Default, Debug, Clone, Copy, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct McpCapabilities {

--- a/rust/agent.rs
+++ b/rust/agent.rs
@@ -210,7 +210,7 @@ pub struct NewSessionResponse {
 
 /// Request parameters for loading an existing session.
 ///
-/// Only available if the agent supports the `loadSession` capability.
+/// Only available if the Agent supports the `loadSession` capability.
 ///
 /// See protocol docs: [Loading Sessions](https://agentclientprotocol.com/protocol/session-setup#loading-sessions)
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -234,16 +234,46 @@ pub struct LoadSessionRequest {
 ///
 /// See protocol docs: [MCP Servers](https://agentclientprotocol.com/protocol/session-setup#mcp-servers)
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct McpServer {
-    /// Human-readable name identifying this MCP server.
-    pub name: String,
-    /// Path to the MCP server executable.
-    pub command: PathBuf,
-    /// Command-line arguments to pass to the MCP server.
-    pub args: Vec<String>,
-    /// Environment variables to set when launching the MCP server.
-    pub env: Vec<EnvVariable>,
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum McpServer {
+    /// HTTP transport configuration
+    ///
+    /// Only available when the Agent capabilities indicate `mcp_capabilities.http` is `true`.
+    #[serde(rename_all = "camelCase")]
+    Http {
+        /// Human-readable name identifying this MCP server.
+        name: String,
+        /// URL to the MCP server.
+        url: String,
+        /// HTTP headers to set when making requests to the MCP server.
+        headers: Vec<HttpHeader>,
+    },
+    /// SSE transport configuration
+    ///
+    /// Only available when the Agent capabilities indicate `mcp_capabilities.sse` is `true`.
+    #[serde(rename_all = "camelCase")]
+    Sse {
+        /// Human-readable name identifying this MCP server.
+        name: String,
+        /// URL to the MCP server.
+        url: String,
+        /// HTTP headers to set when making requests to the MCP server.
+        headers: Vec<HttpHeader>,
+    },
+    /// Stdio transport configuration
+    ///
+    /// All Agents MUST support this transport.
+    #[serde(untagged, rename_all = "camelCase")]
+    Stdio {
+        /// Human-readable name identifying this MCP server.
+        name: String,
+        /// Path to the MCP server executable.
+        command: PathBuf,
+        /// Command-line arguments to pass to the MCP server.
+        args: Vec<String>,
+        /// Environment variables to set when launching the MCP server.
+        env: Vec<EnvVariable>,
+    },
 }
 
 /// An environment variable to set when launching an MCP server.
@@ -253,6 +283,16 @@ pub struct EnvVariable {
     /// The name of the environment variable.
     pub name: String,
     /// The value to set for the environment variable.
+    pub value: String,
+}
+
+/// An HTTP header to set when making requests to the MCP server.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct HttpHeader {
+    /// The name of the HTTP header.
+    pub name: String,
+    /// The value to set for the HTTP header.
     pub value: String,
 }
 
@@ -339,6 +379,9 @@ pub struct AgentCapabilities {
     /// Prompt capabilities supported by the agent.
     #[serde(default)]
     pub prompt_capabilities: PromptCapabilities,
+    /// MCP capabilities supported by the agent.
+    #[serde(default)]
+    pub mcp_capabilities: McpCapabilities,
 }
 
 /// Prompt capabilities supported by the agent in `session/prompt` requests.
@@ -368,6 +411,21 @@ pub struct PromptCapabilities {
     /// in prompt requests for pieces of context that are referenced in the message.
     #[serde(default)]
     pub embedded_context: bool,
+}
+
+/// MCP transport capabilities supported by the agent.
+///
+/// Indicates which MCP server transport mechanisms the agent can use
+/// to connect to Model Context Protocol servers.
+#[derive(Default, Debug, Clone, Copy, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct McpCapabilities {
+    /// Agent supports [`McpServer::Http`].
+    #[serde(default)]
+    pub http: bool,
+    /// Agent supports [`McpServer::Sse`].
+    #[serde(default)]
+    pub sse: bool,
 }
 
 // Method schema
@@ -470,4 +528,149 @@ pub enum ClientNotification {
 pub struct CancelNotification {
     /// The ID of the session to cancel operations for.
     pub session_id: SessionId,
+}
+
+#[cfg(test)]
+mod test_serialization {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_mcp_server_stdio_serialization() {
+        let server = McpServer::Stdio {
+            name: "test-server".to_string(),
+            command: PathBuf::from("/usr/bin/server"),
+            args: vec!["--port".to_string(), "3000".to_string()],
+            env: vec![EnvVariable {
+                name: "API_KEY".to_string(),
+                value: "secret123".to_string(),
+            }],
+        };
+
+        let json = serde_json::to_value(&server).unwrap();
+        assert_eq!(
+            json,
+            json!({
+                "name": "test-server",
+                "command": "/usr/bin/server",
+                "args": ["--port", "3000"],
+                "env": [
+                    {
+                        "name": "API_KEY",
+                        "value": "secret123"
+                    }
+                ]
+            })
+        );
+
+        let deserialized: McpServer = serde_json::from_value(json).unwrap();
+        match deserialized {
+            McpServer::Stdio {
+                name,
+                command,
+                args,
+                env,
+            } => {
+                assert_eq!(name, "test-server");
+                assert_eq!(command, PathBuf::from("/usr/bin/server"));
+                assert_eq!(args, vec!["--port", "3000"]);
+                assert_eq!(env.len(), 1);
+                assert_eq!(env[0].name, "API_KEY");
+                assert_eq!(env[0].value, "secret123");
+            }
+            _ => panic!("Expected Stdio variant"),
+        }
+    }
+
+    #[test]
+    fn test_mcp_server_http_serialization() {
+        let server = McpServer::Http {
+            name: "http-server".to_string(),
+            url: "https://api.example.com".to_string(),
+            headers: vec![
+                HttpHeader {
+                    name: "Authorization".to_string(),
+                    value: "Bearer token123".to_string(),
+                },
+                HttpHeader {
+                    name: "Content-Type".to_string(),
+                    value: "application/json".to_string(),
+                },
+            ],
+        };
+
+        let json = serde_json::to_value(&server).unwrap();
+        assert_eq!(
+            json,
+            json!({
+                "type": "http",
+                "name": "http-server",
+                "url": "https://api.example.com",
+                "headers": [
+                    {
+                        "name": "Authorization",
+                        "value": "Bearer token123"
+                    },
+                    {
+                        "name": "Content-Type",
+                        "value": "application/json"
+                    }
+                ]
+            })
+        );
+
+        let deserialized: McpServer = serde_json::from_value(json).unwrap();
+        match deserialized {
+            McpServer::Http { name, url, headers } => {
+                assert_eq!(name, "http-server");
+                assert_eq!(url, "https://api.example.com");
+                assert_eq!(headers.len(), 2);
+                assert_eq!(headers[0].name, "Authorization");
+                assert_eq!(headers[0].value, "Bearer token123");
+                assert_eq!(headers[1].name, "Content-Type");
+                assert_eq!(headers[1].value, "application/json");
+            }
+            _ => panic!("Expected Http variant"),
+        }
+    }
+
+    #[test]
+    fn test_mcp_server_sse_serialization() {
+        let server = McpServer::Sse {
+            name: "sse-server".to_string(),
+            url: "https://sse.example.com/events".to_string(),
+            headers: vec![HttpHeader {
+                name: "X-API-Key".to_string(),
+                value: "apikey456".to_string(),
+            }],
+        };
+
+        let json = serde_json::to_value(&server).unwrap();
+        assert_eq!(
+            json,
+            json!({
+                "type": "sse",
+                "name": "sse-server",
+                "url": "https://sse.example.com/events",
+                "headers": [
+                    {
+                        "name": "X-API-Key",
+                        "value": "apikey456"
+                    }
+                ]
+            })
+        );
+
+        let deserialized: McpServer = serde_json::from_value(json).unwrap();
+        match deserialized {
+            McpServer::Sse { name, url, headers } => {
+                assert_eq!(name, "sse-server");
+                assert_eq!(url, "https://sse.example.com/events");
+                assert_eq!(headers.len(), 1);
+                assert_eq!(headers[0].name, "X-API-Key");
+                assert_eq!(headers[0].value, "apikey456");
+            }
+            _ => panic!("Expected Sse variant"),
+        }
+    }
 }

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -8,6 +8,14 @@
           "description": "Whether the agent supports `session/load`.",
           "type": "boolean"
         },
+        "mcpCapabilities": {
+          "$ref": "#/$defs/McpCapabilities",
+          "default": {
+            "http": false,
+            "sse": false
+          },
+          "description": "MCP capabilities supported by the agent."
+        },
         "promptCapabilities": {
           "$ref": "#/$defs/PromptCapabilities",
           "default": {
@@ -593,6 +601,21 @@
       },
       "type": "object"
     },
+    "HttpHeader": {
+      "description": "An HTTP header to set when making requests to the MCP server.",
+      "properties": {
+        "name": {
+          "description": "The name of the HTTP header.",
+          "type": "string"
+        },
+        "value": {
+          "description": "The value to set for the HTTP header.",
+          "type": "string"
+        }
+      },
+      "required": ["name", "value"],
+      "type": "object"
+    },
     "ImageContent": {
       "description": "An image provided to or from an LLM.",
       "properties": {
@@ -650,6 +673,10 @@
           "$ref": "#/$defs/AgentCapabilities",
           "default": {
             "loadSession": false,
+            "mcpCapabilities": {
+              "http": false,
+              "sse": false
+            },
             "promptCapabilities": {
               "audio": false,
               "embeddedContext": false,
@@ -690,7 +717,7 @@
       "x-docs-ignore": true
     },
     "LoadSessionRequest": {
-      "description": "Request parameters for loading an existing session.\n\nOnly available if the agent supports the `loadSession` capability.\n\nSee protocol docs: [Loading Sessions](https://agentclientprotocol.com/protocol/session-setup#loading-sessions)",
+      "description": "Request parameters for loading an existing session.\n\nOnly available if the Agent supports the `loadSession` capability.\n\nSee protocol docs: [Loading Sessions](https://agentclientprotocol.com/protocol/session-setup#loading-sessions)",
       "properties": {
         "cwd": {
           "description": "The working directory for this session.",
@@ -713,34 +740,108 @@
       "x-method": "session/load",
       "x-side": "agent"
     },
-    "McpServer": {
-      "description": "Configuration for connecting to an MCP (Model Context Protocol) server.\n\nMCP servers provide tools and context that the agent can use when\nprocessing prompts.\n\nSee protocol docs: [MCP Servers](https://agentclientprotocol.com/protocol/session-setup#mcp-servers)",
+    "McpCapabilities": {
+      "description": "MCP transport capabilities supported by the agent.\n\nIndicates which MCP server transport mechanisms the agent can use\nto connect to Model Context Protocol servers.",
       "properties": {
-        "args": {
-          "description": "Command-line arguments to pass to the MCP server.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
+        "http": {
+          "default": false,
+          "description": "Agent supports [`McpServer::Http`].",
+          "type": "boolean"
         },
-        "command": {
-          "description": "Path to the MCP server executable.",
-          "type": "string"
-        },
-        "env": {
-          "description": "Environment variables to set when launching the MCP server.",
-          "items": {
-            "$ref": "#/$defs/EnvVariable"
-          },
-          "type": "array"
-        },
-        "name": {
-          "description": "Human-readable name identifying this MCP server.",
-          "type": "string"
+        "sse": {
+          "default": false,
+          "description": "Agent supports [`McpServer::Sse`].",
+          "type": "boolean"
         }
       },
-      "required": ["name", "command", "args", "env"],
       "type": "object"
+    },
+    "McpServer": {
+      "anyOf": [
+        {
+          "description": "HTTP transport configuration\n\nOnly available when the Agent capabilities indicate `mcp_capabilities.http` is `true`.",
+          "properties": {
+            "headers": {
+              "description": "HTTP headers to set when making requests to the MCP server.",
+              "items": {
+                "$ref": "#/$defs/HttpHeader"
+              },
+              "type": "array"
+            },
+            "name": {
+              "description": "Human-readable name identifying this MCP server.",
+              "type": "string"
+            },
+            "type": {
+              "const": "http",
+              "type": "string"
+            },
+            "url": {
+              "description": "URL to the MCP server.",
+              "type": "string"
+            }
+          },
+          "required": ["type", "name", "url", "headers"],
+          "type": "object"
+        },
+        {
+          "description": "SSE transport configuration\n\nOnly available when the Agent capabilities indicate `mcp_capabilities.sse` is `true`.",
+          "properties": {
+            "headers": {
+              "description": "HTTP headers to set when making requests to the MCP server.",
+              "items": {
+                "$ref": "#/$defs/HttpHeader"
+              },
+              "type": "array"
+            },
+            "name": {
+              "description": "Human-readable name identifying this MCP server.",
+              "type": "string"
+            },
+            "type": {
+              "const": "sse",
+              "type": "string"
+            },
+            "url": {
+              "description": "URL to the MCP server.",
+              "type": "string"
+            }
+          },
+          "required": ["type", "name", "url", "headers"],
+          "type": "object"
+        },
+        {
+          "description": "Stdio transport configuration\n\nAll Agents MUST support this transport.",
+          "properties": {
+            "args": {
+              "description": "Command-line arguments to pass to the MCP server.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "command": {
+              "description": "Path to the MCP server executable.",
+              "type": "string"
+            },
+            "env": {
+              "description": "Environment variables to set when launching the MCP server.",
+              "items": {
+                "$ref": "#/$defs/EnvVariable"
+              },
+              "type": "array"
+            },
+            "name": {
+              "description": "Human-readable name identifying this MCP server.",
+              "type": "string"
+            }
+          },
+          "required": ["name", "command", "args", "env"],
+          "title": "stdio",
+          "type": "object"
+        }
+      ],
+      "description": "Configuration for connecting to an MCP (Model Context Protocol) server.\n\nMCP servers provide tools and context that the agent can use when\nprocessing prompts.\n\nSee protocol docs: [MCP Servers](https://agentclientprotocol.com/protocol/session-setup#mcp-servers)"
     },
     "NewSessionRequest": {
       "description": "Request parameters for creating a new session.\n\nSee protocol docs: [Creating a Session](https://agentclientprotocol.com/protocol/session-setup#creating-a-session)",

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -741,7 +741,7 @@
       "x-side": "agent"
     },
     "McpCapabilities": {
-      "description": "MCP transport capabilities supported by the agent.\n\nIndicates which MCP server transport mechanisms the agent can use\nto connect to Model Context Protocol servers.",
+      "description": "MCP capabilities supported by the agent",
       "properties": {
         "http": {
           "default": false,


### PR DESCRIPTION
The MCP server list provided by the Client in `session/new` and `session/load` requests may now include configurations for servers using the HTTP and SSE transports.

There's a new `type` field that can be set to `http` or `sse` respectively.  For backwards compatibility, this field is optional, defaulting to stdio, and new Agent capabilities have been introduced.