### PR TITLE
Use piper instead of async-pipe in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,12 +23,12 @@ version = "0.3.1-alpha.1"
 dependencies = [
  "anyhow",
  "async-broadcast",
- "async-pipe",
  "env_logger",
  "futures",
  "futures-util",
  "log",
  "parking_lot",
+ "piper",
  "pretty_assertions",
  "rustyline",
  "schemars",
@@ -116,13 +116,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-pipe"
-version = "0.1.3"
-source = "git+https://github.com/zed-industries/async-pipe-rs?rev=82d00a04211cf4e1236029aa03e6b6ce2a74c553#82d00a04211cf4e1236029aa03e6b6ce2a74c553"
-dependencies = [
- "futures",
- "log",
-]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -276,6 +273,12 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fd-lock"
@@ -569,6 +572,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "portable-atomic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,12 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
 
 [dev-dependencies]
+env_logger = "0.11"
+futures-util = { version = "0.3", features = ["io"] }
+piper = "0.2"
+pretty_assertions = "1.4.1"
+rustyline = "17.0.1"
+tokio-util = { version = "0.7.16", features = ["compat"] }
 tokio = { version = "1.0", features = [
     "macros",
     "rt",
@@ -53,9 +59,3 @@ tokio = { version = "1.0", features = [
     "process",
     "sync",
 ] }
-tokio-util = { version = "0.7.16", features = ["compat"] }
-futures-util = { version = "0.3", features = ["io"] }
-async-pipe = { git = "https://github.com/zed-industries/async-pipe-rs", rev = "82d00a04211cf4e1236029aa03e6b6ce2a74c553" }
-env_logger = "0.11"
-rustyline = "17.0.1"
-pretty_assertions = "1.4.1"

--- a/rust/rpc_tests.rs
+++ b/rust/rpc_tests.rs
@@ -252,8 +252,8 @@ async fn create_connection_pair(
     client: TestClient,
     agent: TestAgent,
 ) -> (ClientSideConnection, AgentSideConnection) {
-    let (client_to_agent_tx, client_to_agent_rx) = async_pipe::pipe();
-    let (agent_to_client_tx, agent_to_client_rx) = async_pipe::pipe();
+    let (client_to_agent_rx, client_to_agent_tx) = piper::pipe(1024);
+    let (agent_to_client_rx, agent_to_client_tx) = piper::pipe(1024);
 
     let (agent_conn, agent_io_task) = ClientSideConnection::new(
         client.clone(),


### PR DESCRIPTION
Since we were using a fork of an old library, just pulled in the smol
equivalent.

