### PR TITLE
Add goose to docs about available agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Learn more at [agentclientprotocol.com](https://agentclientprotocol.com/).
 - [Gemini](https://github.com/google-gemini/gemini-cli)
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview)
   - [via Zed's SDK adapter](https://github.com/zed-industries/claude-code-acp)
+- [Goose](https://github.com/block/goose)
+  - [via Goose's acp command](https://block.github.io/goose/docs/guides/acp-clients)
 
 ## Libraries and Schema
 


### PR DESCRIPTION
Per conversations with @benbrandt this is a doc contribution to show how to use acp with our open source agent, goose which supports it natively